### PR TITLE
spring最小構成の作成とユーザー一覧取得APIの作成

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,16 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>
@@ -44,11 +49,6 @@
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/officenavi/controller/UserController.java
+++ b/src/main/java/com/example/officenavi/controller/UserController.java
@@ -1,0 +1,32 @@
+package com.example.officenavi.controller;
+
+import com.example.officenavi.domain.user.UserResponse;
+import com.example.officenavi.service.UserService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * ユーザの一覧を取得するエンドポイント
+     * @return
+     */
+    @GetMapping("/users")
+    public List<UserResponse> getUsers() {
+        return userService.getUsers();
+    }
+    
+}

--- a/src/main/java/com/example/officenavi/controller/UserController.java
+++ b/src/main/java/com/example/officenavi/controller/UserController.java
@@ -9,21 +9,30 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * 従業員関連APIを提供するコントローラーです。
+ */
 @RestController
 @RequestMapping("/api")
 public class UserController {
 
     private final UserService userService;
 
+    /**
+     * コンストラクタインジェクションでサービスを受け取ります。
+     *
+     * @param userService 従業員サービス
+     */
     public UserController(UserService userService) {
         this.userService = userService;
     }
 
     /**
-     * 社員の一覧を取得するエンドポイント
-     * @return
+     * 従業員一覧を取得します。
+     *
+     * @return 従業員一覧レスポンス
      */
-    @GetMapping("/employees")
+    @GetMapping("/users")
     public List<UserResponse> getUsers() {
         return userService.getUsers();
     }

--- a/src/main/java/com/example/officenavi/controller/UserController.java
+++ b/src/main/java/com/example/officenavi/controller/UserController.java
@@ -3,7 +3,6 @@ package com.example.officenavi.controller;
 import com.example.officenavi.domain.user.UserResponse;
 import com.example.officenavi.service.UserService;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,10 +20,10 @@ public class UserController {
     }
 
     /**
-     * ユーザの一覧を取得するエンドポイント
+     * 社員の一覧を取得するエンドポイント
      * @return
      */
-    @GetMapping("/users")
+    @GetMapping("/employees")
     public List<UserResponse> getUsers() {
         return userService.getUsers();
     }

--- a/src/main/java/com/example/officenavi/domain/user/UserEntity.java
+++ b/src/main/java/com/example/officenavi/domain/user/UserEntity.java
@@ -10,6 +10,10 @@ public class UserEntity {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    public UserEntity(String name, String email) {
+        this(name, email, null);
+    }
+
     public UserEntity(String name, String email, String passwordHash) {
         this.name = name;
         this.email = email;

--- a/src/main/java/com/example/officenavi/domain/user/UserEntity.java
+++ b/src/main/java/com/example/officenavi/domain/user/UserEntity.java
@@ -2,6 +2,9 @@ package com.example.officenavi.domain.user;
 
 import java.time.LocalDateTime;
 
+/**
+ * 従業員を表すドメインエンティティです。
+ */
 public class UserEntity {
     private Integer id;
     private String name;
@@ -10,10 +13,23 @@ public class UserEntity {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    /**
+     * 一覧取得用途の従業員を生成します。
+     *
+     * @param name 従業員名
+     * @param email メールアドレス
+     */
     public UserEntity(String name, String email) {
         this(name, email, null);
     }
 
+    /**
+     * パスワードハッシュを含む従業員を生成します。
+     *
+     * @param name 従業員名
+     * @param email メールアドレス
+     * @param passwordHash パスワードハッシュ
+     */
     public UserEntity(String name, String email, String passwordHash) {
         this.name = name;
         this.email = email;
@@ -22,53 +38,113 @@ public class UserEntity {
         this.updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * 従業員IDを取得します。
+     *
+     * @return 従業員ID
+     */
     public Integer getId() {
         return id;
     }
 
+    /**
+     * 従業員IDを設定します。
+     *
+     * @param id 従業員ID
+     */
     public void setId(Integer id) {
         this.id = id;
     }
 
+    /**
+     * 従業員名を取得します。
+     *
+     * @return 従業員名
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * 従業員名を設定します。
+     *
+     * @param name 従業員名
+     */
     public void setName(String name) {
         this.name = name;
         this.updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * メールアドレスを取得します。
+     *
+     * @return メールアドレス
+     */
     public String getEmail() {
         return email;
     }
 
+    /**
+     * メールアドレスを設定します。
+     *
+     * @param email メールアドレス
+     */
     public void setEmail(String email) {
         this.email = email;
         this.updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * パスワードハッシュを取得します。
+     *
+     * @return パスワードハッシュ
+     */
     public String getPasswordHash() {
         return passwordHash;
     }
 
+    /**
+     * パスワードハッシュを設定します。
+     *
+     * @param passwordHash パスワードハッシュ
+     */
     public void setPasswordHash(String passwordHash) {
         this.passwordHash = passwordHash;
         this.updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * 作成日時を取得します。
+     *
+     * @return 作成日時
+     */
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
+    /**
+     * 作成日時を設定します。
+     *
+     * @param createdAt 作成日時
+     */
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
+    /**
+     * 更新日時を取得します。
+     *
+     * @return 更新日時
+     */
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
     }
 
+    /**
+     * 更新日時を設定します。
+     *
+     * @param updatedAt 更新日時
+     */
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
     }

--- a/src/main/java/com/example/officenavi/domain/user/UserEntity.java
+++ b/src/main/java/com/example/officenavi/domain/user/UserEntity.java
@@ -1,0 +1,71 @@
+package com.example.officenavi.domain.user;
+
+import java.time.LocalDateTime;
+
+public class UserEntity {
+    private Integer id;
+    private String name;
+    private String email;
+    private String passwordHash;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public UserEntity(String name, String email, String passwordHash) {
+        this.name = name;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/user/UserResponse.java
+++ b/src/main/java/com/example/officenavi/domain/user/UserResponse.java
@@ -1,0 +1,37 @@
+package com.example.officenavi.domain.user;
+
+public class UserResponse {
+    private Integer id;
+    private String name;
+    private String email;
+
+    public UserResponse(Integer id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }   
+}

--- a/src/main/java/com/example/officenavi/domain/user/UserResponse.java
+++ b/src/main/java/com/example/officenavi/domain/user/UserResponse.java
@@ -1,5 +1,8 @@
 package com.example.officenavi.domain.user;
 
+/**
+ * 従業員一覧APIで返却するレスポンスDTOです。
+ */
 public class UserResponse {
     private Integer id;
     private String name;

--- a/src/main/java/com/example/officenavi/repository/UserRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserRepository.java
@@ -13,8 +13,7 @@ public class UserRepository {
 	private static final RowMapper<UserEntity> USER_ROW_MAPPER = (rs, rowNum) -> {
 		UserEntity entity = new UserEntity(
 				rs.getString("name"),
-				rs.getString("email"),
-				rs.getString("password_hash")
+				rs.getString("email")
 		);
 		entity.setId(rs.getInt("id"));
 		entity.setCreatedAt(rs.getTimestamp("created_at").toLocalDateTime());
@@ -30,7 +29,7 @@ public class UserRepository {
 
 	public List<UserEntity> findAll() {
 		String sql = """
-				SELECT id, name, email, password_hash, created_at, updated_at
+				SELECT id, name, email, created_at, updated_at
 				FROM users
 				ORDER BY id ASC
 				""";

--- a/src/main/java/com/example/officenavi/repository/UserRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserRepository.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+/**
+ * 従業員情報のデータアクセスを担当するリポジトリです。
+ */
 @Repository
 public class UserRepository {
 
@@ -23,10 +26,20 @@ public class UserRepository {
 
 	private final JdbcTemplate jdbcTemplate;
 
+	/**
+	 * コンストラクタインジェクションで JdbcTemplate を受け取ります。
+	 *
+	 * @param jdbcTemplate JDBC操作を行うテンプレート
+	 */
 	public UserRepository(JdbcTemplate jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
 	}
 
+	/**
+	 * users テーブルから従業員一覧を取得します。
+	 *
+	 * @return 従業員エンティティ一覧
+	 */
 	public List<UserEntity> findAll() {
 		String sql = """
 				SELECT id, name, email, created_at, updated_at

--- a/src/main/java/com/example/officenavi/repository/UserRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserRepository.java
@@ -1,0 +1,39 @@
+package com.example.officenavi.repository;
+
+import com.example.officenavi.domain.user.UserEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class UserRepository {
+
+	private static final RowMapper<UserEntity> USER_ROW_MAPPER = (rs, rowNum) -> {
+		UserEntity entity = new UserEntity(
+				rs.getString("name"),
+				rs.getString("email"),
+				rs.getString("password_hash")
+		);
+		entity.setId(rs.getInt("id"));
+		entity.setCreatedAt(rs.getTimestamp("created_at").toLocalDateTime());
+		entity.setUpdatedAt(rs.getTimestamp("updated_at").toLocalDateTime());
+		return entity;
+	};
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public UserRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	public List<UserEntity> findAll() {
+		String sql = """
+				SELECT id, name, email, password_hash, created_at, updated_at
+				FROM users
+				ORDER BY id ASC
+				""";
+		return jdbcTemplate.query(sql, USER_ROW_MAPPER);
+	}
+}

--- a/src/main/java/com/example/officenavi/service/UserService.java
+++ b/src/main/java/com/example/officenavi/service/UserService.java
@@ -7,15 +7,28 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * 従業員の業務ロジックを扱うサービスです。
+ */
 @Service
 public class UserService {
 
     private final UserRepository userRepository;
 
+    /**
+     * コンストラクタインジェクションでリポジトリを受け取ります。
+     *
+     * @param userRepository 従業員リポジトリ
+     */
     public UserService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 
+    /**
+     * 従業員一覧を取得し、レスポンス形式へ変換して返します。
+     *
+     * @return 従業員一覧レスポンス
+     */
     public List<UserResponse> getUsers() {
         return userRepository.findAll().stream()
                 .map(this::toResponse)
@@ -23,9 +36,10 @@ public class UserService {
     }
 
     /**
-     * UserEntityをUserResponseに変換するユーティリティメソッド
-     * @param userEntity
-     * @return
+     * UserEntityをUserResponseに変換します。
+     *
+     * @param userEntity 従業員エンティティ
+     * @return 従業員レスポンス
      */
     private UserResponse toResponse(UserEntity userEntity) {
         return new UserResponse(

--- a/src/main/java/com/example/officenavi/service/UserService.java
+++ b/src/main/java/com/example/officenavi/service/UserService.java
@@ -1,0 +1,38 @@
+package com.example.officenavi.service;
+
+import com.example.officenavi.domain.user.UserEntity;
+import com.example.officenavi.domain.user.UserResponse;
+import com.example.officenavi.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<UserResponse> getUsers() {
+        return userRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * UserEntityをUserResponseに変換するユーティリティメソッド
+     * @param userEntity
+     * @return
+     */
+    private UserResponse toResponse(UserEntity userEntity) {
+        return new UserResponse(
+                userEntity.getId(),
+                userEntity.getName(),
+                userEntity.getEmail()
+        );
+    }
+    
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=officenavi

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: officenavi
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:office-navi}
+    username: ${DB_USER:sekinotomoya}
+    password: ${DB_PASS:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: UTC
+
+# server:
+#   servlet:
+#     context-path: /office-navi

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,18 +3,9 @@ spring:
     name: officenavi
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:office-navi}
-    username: ${DB_USER:sekinotomoya}
-    password: ${DB_PASS:postgres}
-  jpa:
-    hibernate:
-      ddl-auto: update
-    open-in-view: false
-    properties:
-      hibernate:
-        format_sql: true
-        jdbc:
-          time_zone: UTC
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${OFFICE_NAVI_DB_NAME:office-navi}
+    username: ${OFFICE_NAVI_DB_USER:postgres}
+    password: ${OFFICE_NAVI_DB_PASS:postgres}
 
 # server:
 #   servlet:


### PR DESCRIPTION
# 概要
- Spring Boot の最小構成を整備し、JDBC（JdbcTemplate）でユーザー一覧を取得するAPIを新規追加しました。
- 併せてDB接続設定を application.yml に統一しました。

# 関連Issue
- Issue: #6 
- Issue: #7 

# 変更内容
- Backend:
  - ユーザー一覧APIを追加（GET /api/users）
  - Repository層に JdbcTemplate + RowMapper で users テーブル取得処理を追加
  - Service層で UserEntity から UserResponse への変換処理を追加
  - Controller / Service / Repository の最小レイヤ構成を整備
  - 依存関係を整理（spring-boot-starter-jdbc, postgresql）
  - application.properties を削除し、application.yml を追加
- Frontend:
  - （QAチーム向け）
  - バックエンドAPI追加に伴い、必要に応じて /api/users 利用のチケット起票をお願いします。

# 動作確認内容
1. 手順:
   - アプリを起動する
   - GET /api/users を実行する
2. 期待結果:
   - 200 OK でユーザー一覧が返る
   - users テーブルが空の場合は空配列が返る
   - DB未接続時はエラーとして検知できる

# リスク・影響範囲
- 影響範囲:
  - ユーザー一覧API（GET /api/users）
  - DB接続設定（application.yml）
- 懸念点:
  - DB接続情報（環境変数）未設定時に起動/実行エラーとなる可能性
  - users テーブル定義とSQL列名が不一致の場合に取得エラーとなる可能性