### PR TITLE
名前、メールアドレス、パスワード登録時に空白もバリデーションされるよう変更

### DIFF
--- a/src/main/java/com/example/officenavi/domain/user/UserRegisterRequest.java
+++ b/src/main/java/com/example/officenavi/domain/user/UserRegisterRequest.java
@@ -11,14 +11,18 @@ import jakarta.validation.constraints.Size;
 public class UserRegisterRequest {
     @NotBlank(message = "名前は必須です")
     @Size(max = 100, message = "名前は1~100文字以内で入力してください")
+    @Pattern(regexp = "^(?!.*[\\s　]).+$", message = "名前に空白（半角/全角）は使用できません")
     private String name;
+
     @NotBlank(message = "メールアドレスは必須です")
     @Size(min = 8, max = 255, message = "メールアドレスは8~255文字以内で入力してください")
     @Email(message = "有効なメールアドレスを入力してください")
+    @Pattern(regexp = "^(?!.*[\\s　]).+$", message = "メールアドレスに空白（半角/全角）は使用できません")
     private String email;
+
     @NotBlank(message = "パスワードは必須です")
-    @Size(min = 8, max = 255, message = "パスワードは8~255文字以内で入力してください")  
-    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$",message = "passwordは大文字・小文字・数字をそれぞれ1文字以上含めてください")
+    @Size(min = 8, max = 255, message = "パスワードは8~255文字以内で入力してください")
+    @Pattern(regexp = "^(?!.*[\\s　])(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", message = "パスワードは空白なしで、大文字・小文字・数字をそれぞれ1文字以上含めてください")
     private String password;
 
     public UserRegisterRequest() {


### PR DESCRIPTION
# 概要
- PRレビューで指摘された社員登録APIの不足点を修正し、API仕様書に準拠するように実装を更新しました。
- 主に「201レスポンスボディ返却」「入力バリデーション適用」「メール重複時の409返却」を対応しています。

# 関連Issue
- Issue: #8

# 変更内容
- Backend:
  - `POST /api/users` のレスポンスを `201 Created + ボディ` に変更（`id`, `name`, `email`, `createdAt`）
  - 登録結果返却用DTOを追加
  - Repositoryの登録処理を `RETURNING` で作成ユーザーを返す実装に変更
  - `UserRegisterRequest` にバリデーションを追加
    - 必須チェック、文字数、メール形式
    - パスワード複雑性（大文字/小文字/数字を各1文字以上）
    - 空白禁止（半角/全角）
  - Controllerで `@Valid` を適用し、不正入力時に400を返却
  - `ApiExceptionHandler` を追加
    - バリデーションエラーを400で整形して返却
    - passwordは `rejectedValue` を返さない
    - メール重複（一意制約違反）を409で返却
- Frontend:
  - なし
- Docs:
  - API設計書に `UserRegisterRequest` のバリデーション条件を追記
  - READMEにAPI仕様ドキュメント参照を追記

# 動作確認内容
1. 手順:
   - `POST /api/users` に正常データを送信
   - 不正データ（空文字、形式不正メール、条件未満パスワード、空白含む値）を送信
   - 既存メールアドレスで再登録を実行
2. 期待結果:
   - 正常時: `201 Created` と作成ユーザー情報を返却
   - 不正入力時: `400 Bad Request` を返却し、エラー詳細を返却
   - メール重複時: `409 Conflict` を返却

# リスク・影響範囲
- 影響範囲:
  - 社員登録API（Controller / Service / Repository）
  - 例外ハンドリング（API共通）
- 懸念点:
  - バリデーションメッセージ変更により、フロント側の表示文言依存がある場合は調整が必要