### PR TITLE
在席情報登録APIの実装（座席重複利用の競合エラー対応）

### DIFF
--- a/src/main/java/com/example/officenavi/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/example/officenavi/controller/ApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.example.officenavi.controller;
 
+import com.example.officenavi.exception.ResourceNotFoundException;
+import com.example.officenavi.exception.SeatAlreadyInUseException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -56,6 +58,41 @@ public class ApiExceptionHandler {
                 "reason", "既に使用されているメールアドレスです"
         ));
         response.put("details", details);
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
+    /**
+     * リソース未存在エラーを処理します。
+     *
+     * @param ex リソース未存在例外
+     * @return 404レスポンス
+     */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleResourceNotFound(ResourceNotFoundException ex) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("code", ex.getCode());
+        response.put("message", ex.getMessage());
+        response.put("details", List.of());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    /**
+     * 座席利用中エラーを処理します。
+     *
+     * @param ex 座席利用中例外
+     * @return 409レスポンス
+     */
+    @ExceptionHandler(SeatAlreadyInUseException.class)
+    public ResponseEntity<Map<String, Object>> handleSeatAlreadyInUse(SeatAlreadyInUseException ex) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("code", ex.getCode());
+        response.put("message", ex.getMessage());
+        response.put("details", List.of(Map.of(
+                "field", "seatId",
+                "reason", "既に他のユーザーが利用中です"
+        )));
 
         return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }

--- a/src/main/java/com/example/officenavi/controller/UserSeatController.java
+++ b/src/main/java/com/example/officenavi/controller/UserSeatController.java
@@ -1,0 +1,44 @@
+package com.example.officenavi.controller;
+
+import com.example.officenavi.domain.userseat.UserSeatRegisterRequest;
+import com.example.officenavi.domain.userseat.UserSeatRegisterResponse;
+import com.example.officenavi.service.UserSeatService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 在席情報関連APIを提供するコントローラーです。
+ */
+@RestController
+@RequestMapping("/api")
+public class UserSeatController {
+
+    private final UserSeatService userSeatService;
+
+    /**
+     * コンストラクタインジェクションでサービスを受け取ります。
+     *
+     * @param userSeatService 在席情報サービス
+     */
+    public UserSeatController(UserSeatService userSeatService) {
+        this.userSeatService = userSeatService;
+    }
+
+    /**
+     * 社員の現在位置を登録します。
+     *
+     * @param request 在席情報登録リクエスト
+     * @return 201 Created（登録した在席情報）
+     */
+    @PostMapping("/user-seats")
+    public ResponseEntity<UserSeatRegisterResponse> registerCurrentSeat(
+            @Valid @RequestBody UserSeatRegisterRequest request) {
+        UserSeatRegisterResponse response = userSeatService.registerCurrentSeat(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/userseat/UserSeatEntity.java
+++ b/src/main/java/com/example/officenavi/domain/userseat/UserSeatEntity.java
@@ -1,0 +1,36 @@
+package com.example.officenavi.domain.userseat;
+
+import java.time.LocalDateTime;
+
+/**
+ * user_seats テーブルを表すエンティティです。
+ */
+public class UserSeatEntity {
+    private Integer id;
+    private Integer userId;
+    private Integer seatId;
+    private LocalDateTime startTime;
+
+    public UserSeatEntity(Integer id, Integer userId, Integer seatId, LocalDateTime startTime) {
+        this.id = id;
+        this.userId = userId;
+        this.seatId = seatId;
+        this.startTime = startTime;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public Integer getSeatId() {
+        return seatId;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/userseat/UserSeatRegisterRequest.java
+++ b/src/main/java/com/example/officenavi/domain/userseat/UserSeatRegisterRequest.java
@@ -1,0 +1,31 @@
+package com.example.officenavi.domain.userseat;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 社員の現在位置登録APIリクエストです。
+ */
+public class UserSeatRegisterRequest {
+
+    @NotNull(message = "userIdは必須です")
+    private Integer userId;
+
+    @NotNull(message = "seatIdは必須です")
+    private Integer seatId;
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public Integer getSeatId() {
+        return seatId;
+    }
+
+    public void setSeatId(Integer seatId) {
+        this.seatId = seatId;
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/userseat/UserSeatRegisterResponse.java
+++ b/src/main/java/com/example/officenavi/domain/userseat/UserSeatRegisterResponse.java
@@ -1,0 +1,52 @@
+package com.example.officenavi.domain.userseat;
+
+import java.time.LocalDateTime;
+
+/**
+ * 社員の現在位置登録APIレスポンスです。
+ */
+public class UserSeatRegisterResponse {
+    private Integer userSeatId;
+    private Integer userId;
+    private Integer seatId;
+    private LocalDateTime startTime;
+
+    public UserSeatRegisterResponse(Integer userSeatId, Integer userId, Integer seatId, LocalDateTime startTime) {
+        this.userSeatId = userSeatId;
+        this.userId = userId;
+        this.seatId = seatId;
+        this.startTime = startTime;
+    }
+
+    public Integer getUserSeatId() {
+        return userSeatId;
+    }
+
+    public void setUserSeatId(Integer userSeatId) {
+        this.userSeatId = userSeatId;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public Integer getSeatId() {
+        return seatId;
+    }
+
+    public void setSeatId(Integer seatId) {
+        this.seatId = seatId;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+}

--- a/src/main/java/com/example/officenavi/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/officenavi/exception/ResourceNotFoundException.java
@@ -1,0 +1,17 @@
+package com.example.officenavi.exception;
+
+/**
+ * リソースが存在しない場合の例外です。
+ */
+public class ResourceNotFoundException extends RuntimeException {
+    private final String code;
+
+    public ResourceNotFoundException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/officenavi/exception/SeatAlreadyInUseException.java
+++ b/src/main/java/com/example/officenavi/exception/SeatAlreadyInUseException.java
@@ -1,0 +1,28 @@
+package com.example.officenavi.exception;
+
+/**
+ * 指定座席が既に利用中の場合の例外です。
+ */
+public class SeatAlreadyInUseException extends RuntimeException {
+    private final String code;
+
+    /**
+     * 例外を生成します。
+     *
+     * @param code エラーコード
+     * @param message エラーメッセージ
+     */
+    public SeatAlreadyInUseException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    /**
+     * エラーコードを返します。
+     *
+     * @return エラーコード
+     */
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
@@ -1,0 +1,118 @@
+package com.example.officenavi.repository;
+
+import com.example.officenavi.domain.userseat.UserSeatEntity;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 在席情報のデータアクセスを担当するリポジトリです。
+ */
+@Repository
+public class UserSeatRepository {
+
+    private static final RowMapper<UserSeatEntity> USER_SEAT_ROW_MAPPER = (rs, rowNum) -> new UserSeatEntity(
+            rs.getInt("id"),
+            rs.getInt("user_id"),
+            rs.getInt("seat_id"),
+            rs.getTimestamp("start_time").toLocalDateTime()
+    );
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    /**
+     * コンストラクタインジェクションで JDBC テンプレートを受け取ります。
+     *
+     * @param jdbcTemplate JDBC操作を行うテンプレート
+     */
+    public UserSeatRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * users テーブルに指定ユーザーが存在するかを判定します。
+     *
+     * @param userId ユーザーID
+     * @return 存在する場合は true
+     */
+    public boolean existsUser(Integer userId) {
+        String sql = "SELECT EXISTS(SELECT 1 FROM users WHERE id = :userId)";
+        SqlParameterSource param = new MapSqlParameterSource().addValue("userId", userId);
+        Boolean result = jdbcTemplate.queryForObject(sql, param, Boolean.class);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /**
+     * seats テーブルに指定座席が存在するかを判定します。
+     *
+     * @param seatId 座席ID
+     * @return 存在する場合は true
+     */
+    public boolean existsSeat(Integer seatId) {
+        String sql = "SELECT EXISTS(SELECT 1 FROM seats WHERE id = :seatId)";
+        SqlParameterSource param = new MapSqlParameterSource().addValue("seatId", seatId);
+        Boolean result = jdbcTemplate.queryForObject(sql, param, Boolean.class);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /**
+     * 指定座席が他ユーザーにより現在利用中かを判定します。
+     *
+     * @param seatId 座席ID
+     * @param userId 登録対象ユーザーID
+     * @return 他ユーザーが利用中の場合は true
+     */
+    public boolean isSeatInUseByAnotherUser(Integer seatId, Integer userId) {
+        String sql = """
+                SELECT EXISTS(
+                    SELECT 1
+                    FROM user_seats
+                    WHERE seat_id = :seatId
+                      AND user_id <> :userId
+                      AND end_time IS NULL
+                )
+                """;
+        SqlParameterSource param = new MapSqlParameterSource()
+                .addValue("seatId", seatId)
+                .addValue("userId", userId);
+        Boolean result = jdbcTemplate.queryForObject(sql, param, Boolean.class);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /**
+     * 指定ユーザーの現在有効な在席情報をクローズします。
+     *
+     * @param userId ユーザーID
+     */
+    public void closeCurrentSeat(Integer userId) {
+        String sql = """
+                UPDATE user_seats
+                SET end_time = NOW()
+                WHERE user_id = :userId
+                  AND end_time IS NULL
+                """;
+        SqlParameterSource param = new MapSqlParameterSource().addValue("userId", userId);
+        jdbcTemplate.update(sql, param);
+    }
+
+    /**
+     * 指定ユーザーの現在位置を新規登録します。
+     *
+     * @param userId ユーザーID
+     * @param seatId 座席ID
+     * @return 登録後の在席情報
+     */
+    public UserSeatEntity registerCurrentSeat(Integer userId, Integer seatId) {
+        String sql = """
+                INSERT INTO user_seats (user_id, seat_id, start_time, end_time, created_at)
+                VALUES (:userId, :seatId, NOW(), NULL, NOW())
+                RETURNING id, user_id, seat_id, start_time
+                """;
+        SqlParameterSource param = new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("seatId", seatId);
+        return jdbcTemplate.queryForObject(sql, param, USER_SEAT_ROW_MAPPER);
+    }
+}

--- a/src/main/java/com/example/officenavi/service/UserSeatService.java
+++ b/src/main/java/com/example/officenavi/service/UserSeatService.java
@@ -1,0 +1,60 @@
+package com.example.officenavi.service;
+
+import com.example.officenavi.domain.userseat.UserSeatEntity;
+import com.example.officenavi.domain.userseat.UserSeatRegisterRequest;
+import com.example.officenavi.domain.userseat.UserSeatRegisterResponse;
+import com.example.officenavi.exception.ResourceNotFoundException;
+import com.example.officenavi.exception.SeatAlreadyInUseException;
+import com.example.officenavi.repository.UserSeatRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 在席情報の業務ロジックを扱うサービスです。
+ */
+@Service
+public class UserSeatService {
+
+    private final UserSeatRepository userSeatRepository;
+
+    /**
+     * コンストラクタインジェクションでリポジトリを受け取ります。
+     *
+     * @param userSeatRepository 在席情報リポジトリ
+     */
+    public UserSeatService(UserSeatRepository userSeatRepository) {
+        this.userSeatRepository = userSeatRepository;
+    }
+
+    /**
+     * 社員の現在位置を登録します。
+     * 存在チェック後、既存の有効在席情報をクローズして新規登録します。
+     *
+     * @param request 在席情報登録リクエスト
+     * @return 在席情報登録レスポンス
+     */
+    @Transactional
+    public UserSeatRegisterResponse registerCurrentSeat(UserSeatRegisterRequest request) {
+        if (!userSeatRepository.existsUser(request.getUserId())) {
+            throw new ResourceNotFoundException("USER_NOT_FOUND", "指定されたuserIdは存在しません");
+        }
+
+        if (!userSeatRepository.existsSeat(request.getSeatId())) {
+            throw new ResourceNotFoundException("SEAT_NOT_FOUND", "指定されたseatIdは存在しません");
+        }
+
+        if (userSeatRepository.isSeatInUseByAnotherUser(request.getSeatId(), request.getUserId())) {
+            throw new SeatAlreadyInUseException("SEAT_ALREADY_IN_USE", "指定されたseatIdは既に利用中です");
+        }
+
+        userSeatRepository.closeCurrentSeat(request.getUserId());
+        UserSeatEntity userSeatEntity = userSeatRepository.registerCurrentSeat(request.getUserId(), request.getSeatId());
+
+        return new UserSeatRegisterResponse(
+                userSeatEntity.getId(),
+                userSeatEntity.getUserId(),
+                userSeatEntity.getSeatId(),
+                userSeatEntity.getStartTime()
+        );
+    }
+}


### PR DESCRIPTION
# 概要
- 社員の現在位置登録API（POST /api/user-seats）を実装しました。
- userId / seatId の存在チェック、既存在席のクローズ、新規在席登録を追加しました。
- 既に他ユーザーが同じ座席を利用中の場合に 409 Conflict を返すようにしました。

# 関連Issue
- Issue: #9

# 変更内容
- Backend:
  - 在席登録用のRequest/Response/Entityを追加
  - UserSeatRepository に存在チェック・座席利用中チェック・在席クローズ・新規登録処理を追加
  - UserSeatService に業務ルール（404/409判定、登録フロー）を追加
  - UserSeatController に POST /api/user-seats を追加
  - ApiExceptionHandler に座席利用中例外（SEAT_ALREADY_IN_USE）の 409 ハンドリングを追加
- Frontend:
  - なし

# 動作確認内容
1. 手順:
   - 正常な userId / seatId で POST /api/user-seats を実行
   - 存在しない userId / seatId で実行
   - 他ユーザーが利用中の seatId で実行
2. 期待結果:
   - 正常時: 201 Created で在席情報を返却
   - userId/seatId 未存在: 404 Not Found
   - 座席利用中: 409 Conflict（code: SEAT_ALREADY_IN_USE）

# リスク・影響範囲
- 影響範囲:
  - 在席情報登録APIと例外ハンドリング
- 懸念点:
  - 同時更新時の競合制御は将来的にDB制約・ロック設計で強化余地あり