### PR TITLE
ユーザー退席機能の追加

### DIFF
--- a/src/main/java/com/example/officenavi/controller/UserSeatController.java
+++ b/src/main/java/com/example/officenavi/controller/UserSeatController.java
@@ -1,5 +1,7 @@
 package com.example.officenavi.controller;
 
+import com.example.officenavi.domain.userseat.UserSeatLeaveRequest;
+import com.example.officenavi.domain.userseat.UserSeatLeaveResponse;
 import com.example.officenavi.domain.userseat.UserSeatRegisterRequest;
 import com.example.officenavi.domain.userseat.UserSeatRegisterResponse;
 import com.example.officenavi.service.UserSeatService;
@@ -40,5 +42,18 @@ public class UserSeatController {
             @Valid @RequestBody UserSeatRegisterRequest request) {
         UserSeatRegisterResponse response = userSeatService.registerCurrentSeat(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 社員を退席状態に更新します。
+     *
+     * @param request 退席リクエスト
+     * @return 200 OK（退席情報）
+     */
+    @PostMapping("/user-seats/leave")
+    public ResponseEntity<UserSeatLeaveResponse> leaveCurrentSeat(
+            @Valid @RequestBody UserSeatLeaveRequest request) {
+        UserSeatLeaveResponse response = userSeatService.leaveCurrentSeat(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/officenavi/domain/userseat/UserSeatLeaveRequest.java
+++ b/src/main/java/com/example/officenavi/domain/userseat/UserSeatLeaveRequest.java
@@ -1,0 +1,20 @@
+package com.example.officenavi.domain.userseat;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 社員の退席APIリクエストです。
+ */
+public class UserSeatLeaveRequest {
+
+    @NotNull(message = "userIdは必須です")
+    private Integer userId;
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/userseat/UserSeatLeaveResponse.java
+++ b/src/main/java/com/example/officenavi/domain/userseat/UserSeatLeaveResponse.java
@@ -1,0 +1,33 @@
+package com.example.officenavi.domain.userseat;
+
+import java.time.LocalDateTime;
+
+/**
+ * 社員の退席APIレスポンスです。
+ */
+public class UserSeatLeaveResponse {
+
+    private Integer userId;
+    private LocalDateTime leftAt;
+
+    public UserSeatLeaveResponse(Integer userId, LocalDateTime leftAt) {
+        this.userId = userId;
+        this.leftAt = leftAt;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public LocalDateTime getLeftAt() {
+        return leftAt;
+    }
+
+    public void setLeftAt(LocalDateTime leftAt) {
+        this.leftAt = leftAt;
+    }
+}

--- a/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
@@ -7,6 +7,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
 /**
  * 在席情報のデータアクセスを担当するリポジトリです。
  */
@@ -95,6 +97,32 @@ public class UserSeatRepository {
                 """;
         SqlParameterSource param = new MapSqlParameterSource().addValue("userId", userId);
         jdbcTemplate.update(sql, param);
+    }
+
+    /**
+     * 指定ユーザーの現在有効な在席情報を1件クローズします。
+     *
+     * @param userId ユーザーID
+     * @param leftAt 退席時刻
+     * @return 更新件数
+     */
+    public int closeOneCurrentSeat(Integer userId, LocalDateTime leftAt) {
+        String sql = """
+                UPDATE user_seats
+                SET end_time = :leftAt
+                WHERE id = (
+                    SELECT id
+                    FROM user_seats
+                    WHERE user_id = :userId
+                      AND end_time IS NULL
+                    ORDER BY start_time DESC
+                    LIMIT 1
+                )
+                """;
+        SqlParameterSource param = new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("leftAt", leftAt);
+        return jdbcTemplate.update(sql, param);
     }
 
     /**

--- a/src/main/java/com/example/officenavi/service/UserSeatService.java
+++ b/src/main/java/com/example/officenavi/service/UserSeatService.java
@@ -1,6 +1,8 @@
 package com.example.officenavi.service;
 
 import com.example.officenavi.domain.userseat.UserSeatEntity;
+import com.example.officenavi.domain.userseat.UserSeatLeaveRequest;
+import com.example.officenavi.domain.userseat.UserSeatLeaveResponse;
 import com.example.officenavi.domain.userseat.UserSeatRegisterRequest;
 import com.example.officenavi.domain.userseat.UserSeatRegisterResponse;
 import com.example.officenavi.exception.ResourceNotFoundException;
@@ -8,6 +10,8 @@ import com.example.officenavi.exception.SeatAlreadyInUseException;
 import com.example.officenavi.repository.UserSeatRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 /**
  * 在席情報の業務ロジックを扱うサービスです。
@@ -56,5 +60,28 @@ public class UserSeatService {
                 userSeatEntity.getSeatId(),
                 userSeatEntity.getStartTime()
         );
+    }
+
+    /**
+     * 社員を退席状態に更新します。
+     *
+     * @param request 退席リクエスト
+     * @return 退席レスポンス
+     */
+    @Transactional
+    public UserSeatLeaveResponse leaveCurrentSeat(UserSeatLeaveRequest request) {
+        Integer userId = request.getUserId();
+
+        if (!userSeatRepository.existsUser(userId)) {
+            throw new ResourceNotFoundException("USER_NOT_FOUND", "指定されたuserIdは存在しません");
+        }
+
+        LocalDateTime leftAt = LocalDateTime.now();
+        int updatedCount = userSeatRepository.closeOneCurrentSeat(userId, leftAt);
+        if (updatedCount == 0) {
+            throw new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND", "対象ユーザーの現在位置が登録されていません");
+        }
+
+        return new UserSeatLeaveResponse(userId, leftAt);
     }
 }


### PR DESCRIPTION
# 概要
- 社員の退席API（POST /api/user-seats/leave）を追加し、在席状態を終了できるようにしました。
- MVP設計書にある「社員の退席」機能の未実装分を補完する対応です。

# 関連Issue
- Issue: #17 

# 変更内容
- Backend:
  - 退席APIエンドポイントを追加（POST /api/user-seats/leave）
  - 退席リクエストDTOを追加（userId）
  - 退席レスポンスDTOを追加（userId, leftAt）
  - 退席サービス処理を追加
    - userId存在チェック（未存在は404）
    - 在席レコードのクローズ（end_time更新）
    - 在席情報なしの場合は404（CURRENT_SEAT_NOT_FOUND）
  - Repositoryに「有効在席レコードを1件クローズする」処理を追加
  - API設計書に退席API仕様を反映
- Frontend:
  - なし

# 動作確認内容
1. 手順:
   - POST /api/user-seats で在席登録後、POST /api/user-seats/leave に {"userId": <対象ID>} を送信
   - 在席情報がないユーザーに対して同APIを実行
   - 存在しないuserIdで同APIを実行
2. 期待結果:
   - 在席中ユーザーは200 OKで退席でき、leftAtが返る
   - 在席情報なしユーザーは404（CURRENT_SEAT_NOT_FOUND）
   - 存在しないuserIdは404（USER_NOT_FOUND）

# リスク・影響範囲
- 影響範囲:
  - user_seatsテーブル更新処理（退席時のend_time更新）
  - 在席関連API（/api/user-seats）周辺
- 懸念点:
  - 同時実行時に同一ユーザーへ複数退席リクエストが来た場合の競合挙動