### PR TITLE
座席一覧取得機能の追加

### DIFF
--- a/src/main/java/com/example/officenavi/controller/SeatController.java
+++ b/src/main/java/com/example/officenavi/controller/SeatController.java
@@ -1,0 +1,38 @@
+package com.example.officenavi.controller;
+
+import com.example.officenavi.domain.seat.SeatResponse;
+import com.example.officenavi.service.SeatService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 座席関連APIを提供するコントローラーです。
+ */
+@RestController
+@RequestMapping("/api")
+public class SeatController {
+
+    private final SeatService seatService;
+
+    /**
+     * コンストラクタインジェクションでサービスを受け取ります。
+     *
+     * @param seatService 座席サービス
+     */
+    public SeatController(SeatService seatService) {
+        this.seatService = seatService;
+    }
+
+    /**
+     * 座席一覧を取得します。
+     *
+     * @return 座席一覧レスポンス
+     */
+    @GetMapping("/seats")
+    public List<SeatResponse> getSeats() {
+        return seatService.getSeats();
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/seat/SeatEntity.java
+++ b/src/main/java/com/example/officenavi/domain/seat/SeatEntity.java
@@ -1,0 +1,41 @@
+package com.example.officenavi.domain.seat;
+
+/**
+ * 座席情報エンティティです。
+ */
+public class SeatEntity {
+
+    private Integer id;
+    private String name;
+    private String location;
+
+    public SeatEntity(Integer id, String name, String location) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/seat/SeatResponse.java
+++ b/src/main/java/com/example/officenavi/domain/seat/SeatResponse.java
@@ -1,0 +1,41 @@
+package com.example.officenavi.domain.seat;
+
+/**
+ * 座席一覧取得APIレスポンスです。
+ */
+public class SeatResponse {
+
+    private Integer id;
+    private String name;
+    private String location;
+
+    public SeatResponse(Integer id, String name, String location) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}

--- a/src/main/java/com/example/officenavi/repository/SeatRepository.java
+++ b/src/main/java/com/example/officenavi/repository/SeatRepository.java
@@ -1,0 +1,46 @@
+package com.example.officenavi.repository;
+
+import com.example.officenavi.domain.seat.SeatEntity;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 座席情報のデータアクセスを担当するリポジトリです。
+ */
+@Repository
+public class SeatRepository {
+
+    private static final RowMapper<SeatEntity> SEAT_ROW_MAPPER = (rs, rowNum) -> new SeatEntity(
+            rs.getInt("id"),
+            rs.getString("name"),
+            rs.getString("location")
+    );
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    /**
+     * コンストラクタインジェクションで NamedParameterJdbcTemplate を受け取ります。
+     *
+     * @param jdbcTemplate JDBC操作を行うテンプレート
+     */
+    public SeatRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * seats テーブルから座席一覧を取得します。
+     *
+     * @return 座席エンティティ一覧
+     */
+    public List<SeatEntity> findAll() {
+        String sql = """
+                SELECT id, name, location
+                FROM seats
+                ORDER BY id ASC
+                """;
+        return jdbcTemplate.query(sql, SEAT_ROW_MAPPER);
+    }
+}

--- a/src/main/java/com/example/officenavi/service/SeatService.java
+++ b/src/main/java/com/example/officenavi/service/SeatService.java
@@ -1,0 +1,51 @@
+package com.example.officenavi.service;
+
+import com.example.officenavi.domain.seat.SeatEntity;
+import com.example.officenavi.domain.seat.SeatResponse;
+import com.example.officenavi.repository.SeatRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 座席情報の業務ロジックを扱うサービスです。
+ */
+@Service
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+
+    /**
+     * コンストラクタインジェクションでリポジトリを受け取ります。
+     *
+     * @param seatRepository 座席情報リポジトリ
+     */
+    public SeatService(SeatRepository seatRepository) {
+        this.seatRepository = seatRepository;
+    }
+
+    /**
+     * 座席一覧を取得し、レスポンス形式へ変換して返します。
+     *
+     * @return 座席一覧レスポンス
+     */
+    public List<SeatResponse> getSeats() {
+        return seatRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * SeatEntity を SeatResponse に変換します。
+     *
+     * @param seatEntity 座席エンティティ
+     * @return 座席レスポンス
+     */
+    private SeatResponse toResponse(SeatEntity seatEntity) {
+        return new SeatResponse(
+                seatEntity.getId(),
+                seatEntity.getName(),
+                seatEntity.getLocation()
+        );
+    }
+}


### PR DESCRIPTION
# 概要
- 座席（エリア）一覧取得機能を追加しました。
- MVP設計にある `GET /api/seats` を実装し、座席選択に必要なマスタデータを取得できるようにしました。

# 関連Issue
- Issue: #20 

# 変更内容
- Backend:
  - `GET /api/seats` のAPIを追加
  - Controller追加: [src/main/java/com/example/officenavi/controller/SeatController.java](src/main/java/com/example/officenavi/controller/SeatController.java)
  - Service追加: [src/main/java/com/example/officenavi/service/SeatService.java](src/main/java/com/example/officenavi/service/SeatService.java)
  - Repository追加: [src/main/java/com/example/officenavi/repository/SeatRepository.java](src/main/java/com/example/officenavi/repository/SeatRepository.java)
  - ドメイン追加:
    - [src/main/java/com/example/officenavi/domain/seat/SeatEntity.java](src/main/java/com/example/officenavi/domain/seat/SeatEntity.java)
    - [src/main/java/com/example/officenavi/domain/seat/SeatResponse.java](src/main/java/com/example/officenavi/domain/seat/SeatResponse.java)
- Frontend:
  - なし
- Infra/Config:
  - なし（既存 `seats` テーブルを利用）

# 動作確認内容
1. 手順:
   - `seats` テーブルにデータを投入
   - `GET /api/seats` を実行
2. 期待結果:
   - `200 OK` が返る
   - レスポンスが `id`, `name`, `location` を持つ配列で返る
   - データ未登録時は空配列 `[]` が返る

# リスク・影響範囲
- 影響範囲:
  - 座席一覧取得の新規API
- 懸念点:
  - 大量データ時のレスポンスサイズ（今回はMVPのためページング非対応）
