### PR TITLE
feat: 社員の現在位置取得API（GET /api/users/{userId}/current-seat）を追加

### DIFF
--- a/src/main/java/com/example/officenavi/controller/UserSeatController.java
+++ b/src/main/java/com/example/officenavi/controller/UserSeatController.java
@@ -1,5 +1,6 @@
 package com.example.officenavi.controller;
 
+import com.example.officenavi.domain.userseat.UserCurrentSeatResponse;
 import com.example.officenavi.domain.userseat.UserSeatLeaveRequest;
 import com.example.officenavi.domain.userseat.UserSeatLeaveResponse;
 import com.example.officenavi.domain.userseat.UserSeatRegisterRequest;
@@ -8,6 +9,8 @@ import com.example.officenavi.service.UserSeatService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,6 +57,18 @@ public class UserSeatController {
     public ResponseEntity<UserSeatLeaveResponse> leaveCurrentSeat(
             @Valid @RequestBody UserSeatLeaveRequest request) {
         UserSeatLeaveResponse response = userSeatService.leaveCurrentSeat(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 社員の現在位置を取得します。
+     *
+     * @param userId ユーザーID
+     * @return 200 OK（現在位置情報）
+     */
+    @GetMapping("/users/{userId}/current-seat")
+    public ResponseEntity<UserCurrentSeatResponse> getCurrentSeat(@PathVariable Integer userId) {
+        UserCurrentSeatResponse response = userSeatService.getCurrentSeat(userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/officenavi/domain/userseat/UserCurrentSeatEntity.java
+++ b/src/main/java/com/example/officenavi/domain/userseat/UserCurrentSeatEntity.java
@@ -1,0 +1,80 @@
+package com.example.officenavi.domain.userseat;
+
+import java.time.LocalDateTime;
+
+/**
+ * 社員の現在位置情報エンティティです。
+ */
+public class UserCurrentSeatEntity {
+
+    private Integer userId;
+    private String userName;
+    private Integer seatId;
+    private String seatName;
+    private String seatLocation;
+    private LocalDateTime since;
+
+    public UserCurrentSeatEntity(
+            Integer userId,
+            String userName,
+            Integer seatId,
+            String seatName,
+            String seatLocation,
+            LocalDateTime since
+    ) {
+        this.userId = userId;
+        this.userName = userName;
+        this.seatId = seatId;
+        this.seatName = seatName;
+        this.seatLocation = seatLocation;
+        this.since = since;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public Integer getSeatId() {
+        return seatId;
+    }
+
+    public void setSeatId(Integer seatId) {
+        this.seatId = seatId;
+    }
+
+    public String getSeatName() {
+        return seatName;
+    }
+
+    public void setSeatName(String seatName) {
+        this.seatName = seatName;
+    }
+
+    public String getSeatLocation() {
+        return seatLocation;
+    }
+
+    public void setSeatLocation(String seatLocation) {
+        this.seatLocation = seatLocation;
+    }
+
+    public LocalDateTime getSince() {
+        return since;
+    }
+
+    public void setSince(LocalDateTime since) {
+        this.since = since;
+    }
+}

--- a/src/main/java/com/example/officenavi/domain/userseat/UserCurrentSeatResponse.java
+++ b/src/main/java/com/example/officenavi/domain/userseat/UserCurrentSeatResponse.java
@@ -1,0 +1,92 @@
+package com.example.officenavi.domain.userseat;
+
+import java.time.LocalDateTime;
+
+/**
+ * 社員の現在位置取得APIレスポンスです。
+ */
+public class UserCurrentSeatResponse {
+
+    private Integer userId;
+    private String userName;
+    private SeatInfo seat;
+    private LocalDateTime since;
+
+    public UserCurrentSeatResponse(Integer userId, String userName, SeatInfo seat, LocalDateTime since) {
+        this.userId = userId;
+        this.userName = userName;
+        this.seat = seat;
+        this.since = since;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public SeatInfo getSeat() {
+        return seat;
+    }
+
+    public void setSeat(SeatInfo seat) {
+        this.seat = seat;
+    }
+
+    public LocalDateTime getSince() {
+        return since;
+    }
+
+    public void setSince(LocalDateTime since) {
+        this.since = since;
+    }
+
+    /**
+     * 現在位置の座席情報です。
+     */
+    public static class SeatInfo {
+        private Integer id;
+        private String name;
+        private String location;
+
+        public SeatInfo(Integer id, String name, String location) {
+            this.id = id;
+            this.name = name;
+            this.location = location;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+
+        public void setLocation(String location) {
+            this.location = location;
+        }
+    }
+}

--- a/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
@@ -1,5 +1,6 @@
 package com.example.officenavi.repository;
 
+import com.example.officenavi.domain.userseat.UserCurrentSeatEntity;
 import com.example.officenavi.domain.userseat.UserSeatEntity;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -8,12 +9,22 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 /**
  * 在席情報のデータアクセスを担当するリポジトリです。
  */
 @Repository
 public class UserSeatRepository {
+
+    private static final RowMapper<UserCurrentSeatEntity> USER_CURRENT_SEAT_ROW_MAPPER = (rs, rowNum) -> new UserCurrentSeatEntity(
+            rs.getInt("user_id"),
+            rs.getString("user_name"),
+            rs.getInt("seat_id"),
+            rs.getString("seat_name"),
+            rs.getString("seat_location"),
+            rs.getTimestamp("since").toLocalDateTime()
+    );
 
     private static final RowMapper<UserSeatEntity> USER_SEAT_ROW_MAPPER = (rs, rowNum) -> new UserSeatEntity(
             rs.getInt("id"),
@@ -142,5 +153,32 @@ public class UserSeatRepository {
                 .addValue("userId", userId)
                 .addValue("seatId", seatId);
         return jdbcTemplate.queryForObject(sql, param, USER_SEAT_ROW_MAPPER);
+    }
+
+    /**
+     * 指定ユーザーの現在位置を取得します。
+     *
+     * @param userId ユーザーID
+     * @return 現在位置情報（未在席の場合は空）
+     */
+    public Optional<UserCurrentSeatEntity> findCurrentSeatByUserId(Integer userId) {
+        String sql = """
+                SELECT
+                    u.id AS user_id,
+                    u.name AS user_name,
+                    s.id AS seat_id,
+                    s.name AS seat_name,
+                    s.location AS seat_location,
+                    us.start_time AS since
+                FROM user_seats us
+                INNER JOIN users u ON u.id = us.user_id
+                INNER JOIN seats s ON s.id = us.seat_id
+                WHERE us.user_id = :userId
+                  AND us.end_time IS NULL
+                ORDER BY us.start_time DESC
+                LIMIT 1
+                """;
+        SqlParameterSource param = new MapSqlParameterSource().addValue("userId", userId);
+        return jdbcTemplate.query(sql, param, USER_CURRENT_SEAT_ROW_MAPPER).stream().findFirst();
     }
 }

--- a/src/main/java/com/example/officenavi/service/UserSeatService.java
+++ b/src/main/java/com/example/officenavi/service/UserSeatService.java
@@ -1,5 +1,7 @@
 package com.example.officenavi.service;
 
+import com.example.officenavi.domain.userseat.UserCurrentSeatEntity;
+import com.example.officenavi.domain.userseat.UserCurrentSeatResponse;
 import com.example.officenavi.domain.userseat.UserSeatEntity;
 import com.example.officenavi.domain.userseat.UserSeatLeaveRequest;
 import com.example.officenavi.domain.userseat.UserSeatLeaveResponse;
@@ -83,5 +85,34 @@ public class UserSeatService {
         }
 
         return new UserSeatLeaveResponse(userId, leftAt);
+    }
+
+    /**
+     * 社員の現在位置を取得します。
+     *
+     * @param userId ユーザーID
+     * @return 現在位置取得レスポンス
+     */
+    public UserCurrentSeatResponse getCurrentSeat(Integer userId) {
+        if (!userSeatRepository.existsUser(userId)) {
+            throw new ResourceNotFoundException("USER_NOT_FOUND", "指定されたuserIdは存在しません");
+        }
+
+        UserCurrentSeatEntity entity = userSeatRepository.findCurrentSeatByUserId(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "CURRENT_SEAT_NOT_FOUND",
+                        "対象ユーザーの現在位置が登録されていません"
+                ));
+
+        return new UserCurrentSeatResponse(
+                entity.getUserId(),
+                entity.getUserName(),
+                new UserCurrentSeatResponse.SeatInfo(
+                        entity.getSeatId(),
+                        entity.getSeatName(),
+                        entity.getSeatLocation()
+                ),
+                entity.getSince()
+        );
     }
 }


### PR DESCRIPTION
# 概要
- 社員の現在位置取得API（GET /api/users/{userId}/current-seat）を追加しました。
- 指定ユーザーの在席情報（席ID/席名/ロケーション/在席開始時刻）を取得できるようにしました。

# 関連Issue
- Issue: なし

# 変更内容
- Backend:
  - `GET /api/users/{userId}/current-seat` を追加
  - 現在位置取得用DTOを追加（`UserCurrentSeatResponse`, `UserCurrentSeatEntity`）
  - 在席情報取得クエリをRepositoryに追加（users / user_seats / seats のJOIN）
  - Serviceに現在位置取得ロジックを追加
    - ユーザー未存在時: `USER_NOT_FOUND`（404）
    - 在席情報未登録時: `CURRENT_SEAT_NOT_FOUND`（404）
- Frontend:
  - なし

# 動作確認内容
1. 手順:
   - 在席登録済みユーザーで `GET /api/users/{userId}/current-seat` を実行
   - 在席未登録ユーザーで同APIを実行
   - 存在しない `userId` で同APIを実行
2. 期待結果:
   - 在席登録済みユーザーは `200 OK` で現在位置情報を返す
   - 在席未登録ユーザーは `404 (CURRENT_SEAT_NOT_FOUND)` を返す
   - 存在しないユーザーは `404 (USER_NOT_FOUND)` を返す

# リスク・影響範囲
- 影響範囲:
  - 在席情報関連API（`/api/user-seats` 周辺）および `user_seats` 参照処理
- 懸念点:
  - データ不整合で有効在席レコードが複数ある場合、最新1件を返却する実装前提