### PR TITLE
コントローラー層の単体テスト追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/test/java/com/example/officenavi/controller/SeatControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/SeatControllerTest.java
@@ -1,0 +1,45 @@
+package com.example.officenavi.controller;
+
+import com.example.officenavi.domain.seat.SeatResponse;
+import com.example.officenavi.service.SeatService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class SeatControllerTest {
+
+    private MockMvc mockMvc;
+    private SeatService seatService;
+
+    @BeforeEach
+    void setUp() {
+        seatService = mock(SeatService.class);
+        mockMvc = MockMvcBuilders.standaloneSetup(new SeatController(seatService)).build();
+    }
+
+    @Test
+    void getSeats_shouldReturn200AndSeatList() throws Exception {
+        when(seatService.getSeats()).thenReturn(List.of(
+                new SeatResponse(10, "A-01", "3F North"),
+                new SeatResponse(11, "A-02", "3F East")
+        ));
+
+        mockMvc.perform(get("/api/seats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(10))
+                .andExpect(jsonPath("$[0].name").value("A-01"))
+                .andExpect(jsonPath("$[0].location").value("3F North"))
+                .andExpect(jsonPath("$[1].location").value("3F East"));
+                
+                
+    }
+}

--- a/src/test/java/com/example/officenavi/controller/SeatControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/SeatControllerTest.java
@@ -30,8 +30,7 @@ class SeatControllerTest {
     void getSeats_shouldReturn200AndSeatList() throws Exception {
         when(seatService.getSeats()).thenReturn(List.of(
                 new SeatResponse(10, "A-01", "3F North"),
-                new SeatResponse(11, "A-02", "3F East")
-        ));
+                new SeatResponse(11, "A-02", "3F East")));
 
         mockMvc.perform(get("/api/seats"))
                 .andExpect(status().isOk())
@@ -39,7 +38,6 @@ class SeatControllerTest {
                 .andExpect(jsonPath("$[0].name").value("A-01"))
                 .andExpect(jsonPath("$[0].location").value("3F North"))
                 .andExpect(jsonPath("$[1].location").value("3F East"));
-                
-                
+
     }
 }

--- a/src/test/java/com/example/officenavi/controller/UserControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/UserControllerTest.java
@@ -34,48 +34,47 @@ class UserControllerTest {
     private MockMvc mockMvc;
     private UserService userService;
 
-        @BeforeEach
-        void setUp() {
-                userService = mock(UserService.class);
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserService.class);
 
-                LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
-                validator.afterPropertiesSet();
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
 
-                mockMvc = MockMvcBuilders.standaloneSetup(new UserController(userService))
-                        .setControllerAdvice(new ApiExceptionHandler())
-                        .setValidator(validator)
-                        .build();
-        }
+        mockMvc = MockMvcBuilders.standaloneSetup(new UserController(userService))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
 
-        @Test
-        void getUsers_shouldReturn200AndUsers() throws Exception {
-                when(userService.getUsers()).thenReturn(List.of(
-                        new UserResponse(1, "山田太郎", "taro@example.com"),
-                        new UserResponse(2, "佐藤花子", "hanako@example.com")
-                ));
+    @Test
+    void getUsers_shouldReturn200AndUsers() throws Exception {
+        when(userService.getUsers()).thenReturn(List.of(
+                new UserResponse(1, "山田太郎", "taro@example.com"),
+                new UserResponse(2, "佐藤花子", "hanako@example.com")));
 
-                mockMvc.perform(get("/api/users"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$[0].id").value(1))
-                        .andExpect(jsonPath("$[0].name").value("山田太郎"))
-                        .andExpect(jsonPath("$[1].email").value("hanako@example.com"));
-        }
-    
-        @Test
-        void getUsers_whenServiceReturn_EmptyList_shouldReturn200AndEmptyArray() throws Exception {
-                when(userService.getUsers()).thenReturn(List.of());
-                
-                mockMvc.perform(get("/api/users"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$").isArray())
-                        .andExpect(jsonPath("$").isEmpty());
-        }
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("山田太郎"))
+                .andExpect(jsonPath("$[1].email").value("hanako@example.com"));
+    }
 
-        @Test
-        void registerUser_shouldReturn201AndCreatedUser() throws Exception {
+    @Test
+    void getUsers_whenServiceReturn_EmptyList_shouldReturn200AndEmptyArray() throws Exception {
+        when(userService.getUsers()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void registerUser_shouldReturn201AndCreatedUser() throws Exception {
         when(userService.registerUser(any())).thenReturn(
-                new UserRegisterResponse(1, "山田太郎", "taro@example.com", LocalDateTime.of(2026, 3, 3, 10, 0, 0))
-        );
+                new UserRegisterResponse(1, "山田太郎", "taro@example.com",
+                        LocalDateTime.of(2026, 3, 3, 10, 0, 0)));
 
         String body = """
                 {
@@ -86,8 +85,8 @@ class UserControllerTest {
                 """;
 
         mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(1))
                 .andExpect(jsonPath("$.email").value("taro@example.com"));
@@ -100,8 +99,7 @@ class UserControllerTest {
             "Password",
             "Pass word1",
             "Pass1"
-            }
-                )
+    })
     void registerUser_whenInvalidPassword_shouldReturn400(String invalidPassword) throws Exception {
         String body = """
                 {
@@ -112,15 +110,15 @@ class UserControllerTest {
                 """.formatted(invalidPassword);
 
         mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("validation error"))
                 .andExpect(jsonPath("$.errors[*].field", hasItems("password")));
 
         verifyNoInteractions(userService);
     }
-    
+
     @ParameterizedTest
     @ValueSource(strings = {
             "山田 太郎",
@@ -131,22 +129,22 @@ class UserControllerTest {
     void registerUser_whenNameHasWhitespace_shouldReturn400(String invalidName) throws Exception {
         String body = """
                 {
-                  "name": "%s",
-                  "email": "taro@example.com",
-                  "password": "Passw0rd"
+                "name": "%s",
+                "email": "taro@example.com",
+                "password": "Passw0rd"
                 }
                 """.formatted(invalidName);
 
         mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("validation error"))
                 .andExpect(jsonPath("$.errors[*].field", hasItems("name")));
 
         verifyNoInteractions(userService);
     }
-    
+
     @ParameterizedTest
     @ValueSource(strings = {
             "taro @example.com",
@@ -163,16 +161,15 @@ class UserControllerTest {
                 """.formatted(invalidEmail);
 
         mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("validation error"))
                 .andExpect(jsonPath("$.errors[*].field", hasItems("email")));
 
         verifyNoInteractions(userService);
     }
-    
-    
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("invalidRegisterRequestCases")
     void registerUser_whenInvalidRequest_shouldReturn400AndFields(
@@ -180,8 +177,7 @@ class UserControllerTest {
             String name,
             String email,
             String password,
-            List<String> expectedFields
-    ) throws Exception {
+            List<String> expectedFields) throws Exception {
         String body = """
                 {
                   "name": "%s",
@@ -191,22 +187,25 @@ class UserControllerTest {
                 """.formatted(name, email, password);
 
         mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("validation error"))
-                .andExpect(jsonPath("$.errors[*].field", hasItems(expectedFields.toArray(new String[0]))));
+                .andExpect(jsonPath("$.errors[*].field",
+                        hasItems(expectedFields.toArray(new String[0]))));
 
         verifyNoInteractions(userService);
     }
 
     private static Stream<Arguments> invalidRegisterRequestCases() {
         return Stream.of(
-                Arguments.of("name has whitespace", "山田 太郎", "taro@example.com", "Passw0rd", List.of("name")),
+                Arguments.of("name has whitespace", "山田 太郎", "taro@example.com", "Passw0rd",
+                        List.of("name")),
                 Arguments.of("email format invalid", "山田太郎", "invalid", "Passw0rd", List.of("email")),
-                Arguments.of("email has whitespace", "山田太郎", "taro @example.com", "Passw0rd", List.of("email")),
-                Arguments.of("name and email invalid", "山田 太郎", "invalid", "Passw0rd", List.of("name", "email"))
-        );
+                Arguments.of("email has whitespace", "山田太郎", "taro @example.com", "Passw0rd",
+                        List.of("email")),
+                Arguments.of("name and email invalid", "山田 太郎", "invalid", "Passw0rd",
+                        List.of("name", "email")));
     }
 
     @Test
@@ -222,8 +221,8 @@ class UserControllerTest {
                 """;
 
         mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("DUPLICATE_EMAIL"));
     }

--- a/src/test/java/com/example/officenavi/controller/UserControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/UserControllerTest.java
@@ -1,0 +1,230 @@
+package com.example.officenavi.controller;
+
+import com.example.officenavi.domain.user.UserRegisterResponse;
+import com.example.officenavi.domain.user.UserResponse;
+import com.example.officenavi.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserControllerTest {
+
+    private MockMvc mockMvc;
+    private UserService userService;
+
+        @BeforeEach
+        void setUp() {
+                userService = mock(UserService.class);
+
+                LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+                validator.afterPropertiesSet();
+
+                mockMvc = MockMvcBuilders.standaloneSetup(new UserController(userService))
+                        .setControllerAdvice(new ApiExceptionHandler())
+                        .setValidator(validator)
+                        .build();
+        }
+
+        @Test
+        void getUsers_shouldReturn200AndUsers() throws Exception {
+                when(userService.getUsers()).thenReturn(List.of(
+                        new UserResponse(1, "山田太郎", "taro@example.com"),
+                        new UserResponse(2, "佐藤花子", "hanako@example.com")
+                ));
+
+                mockMvc.perform(get("/api/users"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$[0].id").value(1))
+                        .andExpect(jsonPath("$[0].name").value("山田太郎"))
+                        .andExpect(jsonPath("$[1].email").value("hanako@example.com"));
+        }
+    
+        @Test
+        void getUsers_whenServiceReturn_EmptyList_shouldReturn200AndEmptyArray() throws Exception {
+                when(userService.getUsers()).thenReturn(List.of());
+                
+                mockMvc.perform(get("/api/users"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$").isArray())
+                        .andExpect(jsonPath("$").isEmpty());
+        }
+
+        @Test
+        void registerUser_shouldReturn201AndCreatedUser() throws Exception {
+        when(userService.registerUser(any())).thenReturn(
+                new UserRegisterResponse(1, "山田太郎", "taro@example.com", LocalDateTime.of(2026, 3, 3, 10, 0, 0))
+        );
+
+        String body = """
+                {
+                  "name": "山田太郎",
+                  "email": "taro@example.com",
+                  "password": "Passw0rd"
+                }
+                """;
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.email").value("taro@example.com"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "password1",
+            "PASSWORD1",
+            "Password",
+            "Pass word1",
+            "Pass1"
+            }
+                )
+    void registerUser_whenInvalidPassword_shouldReturn400(String invalidPassword) throws Exception {
+        String body = """
+                {
+                  "name": "山田太郎",
+                  "email": "taro@example.com",
+                  "password": "%s"
+                }
+                """.formatted(invalidPassword);
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("password")));
+
+        verifyNoInteractions(userService);
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "山田 太郎",
+            " 山田太郎",
+            "山田太郎 ",
+            "山田　太郎"
+    })
+    void registerUser_whenNameHasWhitespace_shouldReturn400(String invalidName) throws Exception {
+        String body = """
+                {
+                  "name": "%s",
+                  "email": "taro@example.com",
+                  "password": "Passw0rd"
+                }
+                """.formatted(invalidName);
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("name")));
+
+        verifyNoInteractions(userService);
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "taro @example.com",
+            "taro@example .com",
+            "taro@ example.com",
+    })
+    void registerUser_whenEmailInvalid_shouldReturn400(String invalidEmail) throws Exception {
+        String body = """
+                {
+                  "name": "山田太郎",
+                  "email": "%s",
+                  "password": "Passw0rd"
+                }
+                """.formatted(invalidEmail);
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("email")));
+
+        verifyNoInteractions(userService);
+    }
+    
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidRegisterRequestCases")
+    void registerUser_whenInvalidRequest_shouldReturn400AndFields(
+            String caseName,
+            String name,
+            String email,
+            String password,
+            List<String> expectedFields
+    ) throws Exception {
+        String body = """
+                {
+                  "name": "%s",
+                  "email": "%s",
+                  "password": "%s"
+                }
+                """.formatted(name, email, password);
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems(expectedFields.toArray(new String[0]))));
+
+        verifyNoInteractions(userService);
+    }
+
+    private static Stream<Arguments> invalidRegisterRequestCases() {
+        return Stream.of(
+                Arguments.of("name has whitespace", "山田 太郎", "taro@example.com", "Passw0rd", List.of("name")),
+                Arguments.of("email format invalid", "山田太郎", "invalid", "Passw0rd", List.of("email")),
+                Arguments.of("email has whitespace", "山田太郎", "taro @example.com", "Passw0rd", List.of("email")),
+                Arguments.of("name and email invalid", "山田 太郎", "invalid", "Passw0rd", List.of("name", "email"))
+        );
+    }
+
+    @Test
+    void registerUser_whenDuplicateEmail_shouldReturn409() throws Exception {
+        when(userService.registerUser(any())).thenThrow(new DataIntegrityViolationException("duplicate email"));
+
+        String body = """
+                {
+                  "name": "山田太郎",
+                  "email": "taro@example.com",
+                  "password": "Passw0rd"
+                }
+                """;
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_EMAIL"));
+    }
+}

--- a/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
@@ -1,0 +1,230 @@
+package com.example.officenavi.controller;
+
+import com.example.officenavi.domain.userseat.UserCurrentSeatResponse;
+import com.example.officenavi.domain.userseat.UserSeatLeaveResponse;
+import com.example.officenavi.domain.userseat.UserSeatRegisterResponse;
+import com.example.officenavi.exception.ResourceNotFoundException;
+import com.example.officenavi.exception.SeatAlreadyInUseException;
+import com.example.officenavi.service.UserSeatService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserSeatControllerTest {
+
+    private MockMvc mockMvc;
+    private UserSeatService userSeatService;
+
+    @BeforeEach
+    void setUp() {
+        userSeatService = mock(UserSeatService.class);
+
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new UserSeatController(userSeatService))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    void registerCurrentSeat_shouldReturn201() throws Exception {
+        when(userSeatService.registerCurrentSeat(any())).thenReturn(
+                new UserSeatRegisterResponse(100, 1, 10, LocalDateTime.of(2026, 3, 3, 10, 5, 0))
+        );
+
+        String body = """
+                {
+                  "userId": 1,
+                  "seatId": 10
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userSeatId").value(100))
+                .andExpect(jsonPath("$.seatId").value(10));
+    }
+
+    @Test
+    void leaveCurrentSeat_shouldReturn200() throws Exception {
+        when(userSeatService.leaveCurrentSeat(any())).thenReturn(
+                new UserSeatLeaveResponse(1, LocalDateTime.of(2026, 3, 3, 10, 20, 0))
+        );
+
+        String body = """
+                {
+                  "userId": 1
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats/leave")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1));
+    }
+
+    @Test
+    void getCurrentSeat_shouldReturn200() throws Exception {
+        UserCurrentSeatResponse response = new UserCurrentSeatResponse(
+                1,
+                "山田太郎",
+                new UserCurrentSeatResponse.SeatInfo(10, "A-01", "3F East"),
+                LocalDateTime.of(2026, 3, 3, 10, 5, 0)
+        );
+        when(userSeatService.getCurrentSeat(1)).thenReturn(response);
+
+        mockMvc.perform(get("/api/users/1/current-seat"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.seat.id").value(10));
+    }
+
+    @Test
+    void leaveCurrentSeat_whenUserIdMissing_shouldReturn400() throws Exception {
+        String body = "{}";
+
+        mockMvc.perform(post("/api/user-seats/leave")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[0].field").value("userId"));
+    }
+
+    @Test
+    void getCurrentSeat_whenNotFound_shouldReturn404() throws Exception {
+        when(userSeatService.getCurrentSeat(999))
+                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND", "対象ユーザーの現在位置が登録されていません"));
+
+        mockMvc.perform(get("/api/users/999/current-seat"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CURRENT_SEAT_NOT_FOUND"));
+    }
+
+    @Test
+    void registerCurrentSeat_whenUserIdMissing_shouldReturn400() throws Exception {
+        String body = """
+                {
+                  "seatId": 10
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[0].field").value("userId"));
+    }
+
+    @Test
+    void registerCurrentSeat_whenUserNotFound_shouldReturn404() throws Exception {
+        when(userSeatService.registerCurrentSeat(any()))
+                .thenThrow(new ResourceNotFoundException("USER_NOT_FOUND", "指定されたuserIdは存在しません"));
+
+        String body = """
+                {
+                  "userId": 999,
+                  "seatId": 10
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    void registerCurrentSeat_whenSeatNotFound_shouldReturn404() throws Exception {
+        when(userSeatService.registerCurrentSeat(any()))
+                .thenThrow(new ResourceNotFoundException("SEAT_NOT_FOUND", "指定されたseatIdは存在しません"));
+
+        String body = """
+                {
+                  "userId": 1,
+                  "seatId": 999
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SEAT_NOT_FOUND"));
+    }
+
+    @Test
+    void registerCurrentSeat_whenSeatInUse_shouldReturn409() throws Exception {
+        when(userSeatService.registerCurrentSeat(any()))
+                .thenThrow(new SeatAlreadyInUseException("SEAT_ALREADY_IN_USE", "指定されたseatIdは既に利用中です"));
+
+        String body = """
+                {
+                  "userId": 1,
+                  "seatId": 10
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("SEAT_ALREADY_IN_USE"));
+    }
+
+    @Test
+    void leaveCurrentSeat_whenUserNotFound_shouldReturn404() throws Exception {
+        when(userSeatService.leaveCurrentSeat(any()))
+                .thenThrow(new ResourceNotFoundException("USER_NOT_FOUND", "指定されたuserIdは存在しません"));
+
+        String body = """
+                {
+                  "userId": 999
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats/leave")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    void leaveCurrentSeat_whenCurrentSeatNotFound_shouldReturn404() throws Exception {
+        when(userSeatService.leaveCurrentSeat(any()))
+                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND", "対象ユーザーの現在位置が登録されていません"));
+
+        String body = """
+                {
+                  "userId": 1
+                }
+                """;
+
+        mockMvc.perform(post("/api/user-seats/leave")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CURRENT_SEAT_NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
@@ -44,8 +44,7 @@ class UserSeatControllerTest {
     @Test
     void registerCurrentSeat_shouldReturn201() throws Exception {
         when(userSeatService.registerCurrentSeat(any())).thenReturn(
-                new UserSeatRegisterResponse(100, 1, 10, LocalDateTime.of(2026, 3, 3, 10, 5, 0))
-        );
+                new UserSeatRegisterResponse(100, 1, 10, LocalDateTime.of(2026, 3, 3, 10, 5, 0)));
 
         String body = """
                 {
@@ -55,8 +54,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.userSeatId").value(100))
                 .andExpect(jsonPath("$.seatId").value(10));
@@ -65,8 +64,7 @@ class UserSeatControllerTest {
     @Test
     void leaveCurrentSeat_shouldReturn200() throws Exception {
         when(userSeatService.leaveCurrentSeat(any())).thenReturn(
-                new UserSeatLeaveResponse(1, LocalDateTime.of(2026, 3, 3, 10, 20, 0))
-        );
+                new UserSeatLeaveResponse(1, LocalDateTime.of(2026, 3, 3, 10, 20, 0)));
 
         String body = """
                 {
@@ -75,8 +73,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats/leave")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value(1));
     }
@@ -87,8 +85,7 @@ class UserSeatControllerTest {
                 1,
                 "山田太郎",
                 new UserCurrentSeatResponse.SeatInfo(10, "A-01", "3F East"),
-                LocalDateTime.of(2026, 3, 3, 10, 5, 0)
-        );
+                LocalDateTime.of(2026, 3, 3, 10, 5, 0));
         when(userSeatService.getCurrentSeat(1)).thenReturn(response);
 
         mockMvc.perform(get("/api/users/1/current-seat"))
@@ -102,8 +99,8 @@ class UserSeatControllerTest {
         String body = "{}";
 
         mockMvc.perform(post("/api/user-seats/leave")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("validation error"))
                 .andExpect(jsonPath("$.errors[0].field").value("userId"));
@@ -112,7 +109,8 @@ class UserSeatControllerTest {
     @Test
     void getCurrentSeat_whenNotFound_shouldReturn404() throws Exception {
         when(userSeatService.getCurrentSeat(999))
-                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND", "対象ユーザーの現在位置が登録されていません"));
+                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND",
+                        "対象ユーザーの現在位置が登録されていません"));
 
         mockMvc.perform(get("/api/users/999/current-seat"))
                 .andExpect(status().isNotFound())
@@ -128,8 +126,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("validation error"))
                 .andExpect(jsonPath("$.errors[0].field").value("userId"));
@@ -148,8 +146,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
     }
@@ -167,8 +165,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("SEAT_NOT_FOUND"));
     }
@@ -186,8 +184,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("SEAT_ALREADY_IN_USE"));
     }
@@ -204,8 +202,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats/leave")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
     }
@@ -213,7 +211,8 @@ class UserSeatControllerTest {
     @Test
     void leaveCurrentSeat_whenCurrentSeatNotFound_shouldReturn404() throws Exception {
         when(userSeatService.leaveCurrentSeat(any()))
-                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND", "対象ユーザーの現在位置が登録されていません"));
+                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND",
+                        "対象ユーザーの現在位置が登録されていません"));
 
         String body = """
                 {
@@ -222,8 +221,8 @@ class UserSeatControllerTest {
                 """;
 
         mockMvc.perform(post("/api/user-seats/leave")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("CURRENT_SEAT_NOT_FOUND"));
     }


### PR DESCRIPTION
# 概要
- `SeatController` / `UserController` / `UserSeatController` の単体テストを新規追加する。
- テスト実行に必要な `spring-security-test` を `pom.xml` に追加する。

# 関連Issue
- Issue: #26 

# 変更内容
- Backend:
  - `pom.xml`: `spring-security-test`（scope: test）を依存に追加
  - `SeatControllerTest`: `GET /api/seats` の正常系テストを追加
  - `UserControllerTest`:
    - `GET /api/users` 正常系・空リスト返却
    - `POST /api/users` 正常系（201返却）
    - バリデーションエラー系（パスワード強度・名前空白・メール形式）
    - 複合バリデーション（`@MethodSource` による複数フィールド検証）
    - 重複メール → 409
  - `UserSeatControllerTest`:
    - `POST /api/user-seats` 正常系・userId不存在・seatId不存在・座席使用中
    - `POST /api/user-seats/leave` 正常系・userId不存在・在席情報なし
    - `GET /api/users/{userId}/current-seat` 正常系・在席情報なし
- Frontend:
  - なし

# 動作確認内容
1. 手順: `./mvnw test` を実行
2. 期待結果: コントローラー層テスト含む全テストが GREEN

# リスク・影響範囲
- 影響範囲: テストコードと `pom.xml` のみ。本体コードへの影響なし。
- 懸念点: 特になし