### PR TITLE
service層のテストコードを追加しました。

### DIFF
--- a/src/test/java/com/example/officenavi/service/SeatServiceTest.java
+++ b/src/test/java/com/example/officenavi/service/SeatServiceTest.java
@@ -1,0 +1,52 @@
+package com.example.officenavi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.officenavi.domain.seat.SeatEntity;
+import com.example.officenavi.domain.seat.SeatResponse;
+import com.example.officenavi.repository.SeatRepository;
+
+public class SeatServiceTest {
+    
+    private SeatRepository seatRepository;
+    private SeatService seatService;
+    
+    @BeforeEach
+    void setUp() {
+        seatRepository = mock(SeatRepository.class);
+        seatService = new SeatService(seatRepository);
+    }
+    
+    @Test
+    void getSeats_shouldReturnListOfSeats() {
+        when(seatRepository.findAll()).thenReturn(List.of(
+            new SeatEntity(1, "A-01", "3F EAST"),
+            new SeatEntity(2, "A-02", "3F WEST")
+        ));
+
+        List<SeatResponse> seats = seatService.getSeats();
+
+        assertEquals(2, seats.size());
+        assertEquals(1, seats.get(0).getId());
+        assertEquals("A-01", seats.get(0).getName());
+        assertEquals("3F EAST", seats.get(0).getLocation());
+        assertEquals(2, seats.get(1).getId());
+        assertEquals("A-02", seats.get(1).getName());
+        assertEquals("3F WEST", seats.get(1).getLocation());
+    }
+    
+    @Test
+    void getSeats_shouldReturnEmptyListWhenNoSeats() {
+        when(seatRepository.findAll()).thenReturn(List.of());
+
+        List<SeatResponse> seats = seatService.getSeats();
+        assertEquals(0, seats.size());
+    }
+}

--- a/src/test/java/com/example/officenavi/service/UserSeatServiceTest.java
+++ b/src/test/java/com/example/officenavi/service/UserSeatServiceTest.java
@@ -1,0 +1,171 @@
+package com.example.officenavi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import com.example.officenavi.domain.userseat.UserCurrentSeatEntity;
+import com.example.officenavi.domain.userseat.UserCurrentSeatResponse;
+import com.example.officenavi.domain.userseat.UserSeatEntity;
+import com.example.officenavi.domain.userseat.UserSeatLeaveRequest;
+import com.example.officenavi.domain.userseat.UserSeatRegisterRequest;
+import com.example.officenavi.domain.userseat.UserSeatRegisterResponse;
+import com.example.officenavi.exception.ResourceNotFoundException;
+import com.example.officenavi.exception.SeatAlreadyInUseException;
+import com.example.officenavi.repository.UserSeatRepository;
+
+public class UserSeatServiceTest {
+    private static final Integer USER_ID = 100;
+    private static final Integer SEAT_ID = 200;
+
+    private UserSeatRepository userSeatRepository;
+    private UserSeatService userSeatService;
+
+    @BeforeEach
+    void setUp() {
+        userSeatRepository = mock(UserSeatRepository.class);
+        userSeatService = new UserSeatService(userSeatRepository);
+    }
+    
+    @Test
+    void registerCurrentSeat_shouldRegisterSeat() {
+        LocalDateTime now = LocalDateTime.now();
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.existsSeat(SEAT_ID)).thenReturn(true);
+        when(userSeatRepository.isSeatInUseByAnotherUser(SEAT_ID, USER_ID)).thenReturn(false);
+        when(userSeatRepository.registerCurrentSeat(USER_ID, SEAT_ID)).thenReturn(new UserSeatEntity(1, USER_ID, SEAT_ID, now));
+
+        UserSeatRegisterResponse response = userSeatService.registerCurrentSeat(createRegisterRequest());
+
+        assertEquals(USER_ID, response.getUserId());
+        assertEquals(SEAT_ID, response.getSeatId());
+        assertEquals(now, response.getStartTime());
+        assertEquals(1, response.getUserSeatId());
+    }
+    
+    @Test
+    void registerCurrentSeat_shouldThrowExceptionWhenUserNotFound() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> userSeatService.registerCurrentSeat(createRegisterRequest()));
+    }
+    
+    @Test
+    void registerCurrentSeat_shouldThrowExceptionWhenSeatNotFound() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.existsSeat(SEAT_ID)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> userSeatService.registerCurrentSeat(createRegisterRequest()));
+    }
+    
+    @Test
+    void registerCurrentSeat_shouldThrowExceptionWhenSeatAlreadyInUse() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.existsSeat(SEAT_ID)).thenReturn(true);
+        when(userSeatRepository.isSeatInUseByAnotherUser(SEAT_ID, USER_ID)).thenReturn(true);
+
+        assertThrows(SeatAlreadyInUseException.class, () -> userSeatService.registerCurrentSeat(createRegisterRequest()));
+    }
+    
+    @Test
+    void registerCurrentSeat_shouldCloseCurrentSeatAndRegisterNewSeat() {
+        LocalDateTime now = LocalDateTime.now();
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.existsSeat(SEAT_ID)).thenReturn(true);
+        when(userSeatRepository.isSeatInUseByAnotherUser(SEAT_ID, USER_ID)).thenReturn(false);
+        when(userSeatRepository.registerCurrentSeat(USER_ID, SEAT_ID)).thenReturn(new UserSeatEntity(1, USER_ID, SEAT_ID, now));
+
+        userSeatService.registerCurrentSeat(createRegisterRequest());
+        
+        InOrder inOrder = inOrder(userSeatRepository);
+        inOrder.verify(userSeatRepository).closeCurrentSeat(USER_ID);
+        inOrder.verify(userSeatRepository).registerCurrentSeat(USER_ID, SEAT_ID);
+    }
+    
+    @Test
+    void leaveCurrentSeat_shouldLeaveSeat() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.closeOneCurrentSeat(eq(USER_ID), any(LocalDateTime.class))).thenReturn(1);
+
+        var response = userSeatService.leaveCurrentSeat(createLeaveRequest());
+
+        assertEquals(USER_ID, response.getUserId());
+        assertNotNull(response.getLeftAt());
+        verify(userSeatRepository).closeOneCurrentSeat(eq(USER_ID), any(LocalDateTime.class));
+    }
+    
+    @Test
+    void leaveCurrentSeat_shouldThrowExceptionWhenUserNotFound() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> userSeatService.leaveCurrentSeat(createLeaveRequest()));
+    }
+    
+    @Test
+    void leaveCurrentSeat_shouldThrowExceptionWhenNoCurrentSeat() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.closeOneCurrentSeat(eq(USER_ID), any(LocalDateTime.class))).thenReturn(0);
+
+        assertThrows(ResourceNotFoundException.class, () -> userSeatService.leaveCurrentSeat(createLeaveRequest()));
+    }
+    
+    @Test
+    void getCurrentSeat_shouldReturnCurrentSeat() {
+        LocalDateTime now = LocalDateTime.now();
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.findCurrentSeatByUserId(USER_ID)).thenReturn(Optional.of(
+                new UserCurrentSeatEntity(USER_ID, "Test User", SEAT_ID, "Test Seat", "Test Location", now)
+        ));
+
+        UserCurrentSeatResponse response = userSeatService.getCurrentSeat(USER_ID);
+
+        assertEquals(USER_ID, response.getUserId());
+        assertEquals("Test User", response.getUserName());
+        assertEquals(SEAT_ID, response.getSeat().getId());
+        assertEquals("Test Seat", response.getSeat().getName());
+        assertEquals("Test Location", response.getSeat().getLocation());
+        assertEquals(now, response.getSince());
+    }
+    
+    @Test
+    void getCurrentSeat_shouldThrowExceptionWhenUserNotFound() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> userSeatService.getCurrentSeat(USER_ID));
+    }
+    
+    
+    @Test
+    void getCurrentSeat_shouldThrowExceptionWhenNoCurrentSeat() {
+        when(userSeatRepository.existsUser(USER_ID)).thenReturn(true);
+        when(userSeatRepository.findCurrentSeatByUserId(USER_ID)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> userSeatService.getCurrentSeat(USER_ID));
+    }
+
+    private UserSeatRegisterRequest createRegisterRequest() {
+        UserSeatRegisterRequest request = new UserSeatRegisterRequest();
+        request.setUserId(USER_ID);
+        request.setSeatId(SEAT_ID);
+        return request;
+    }
+
+    private UserSeatLeaveRequest createLeaveRequest() {
+        UserSeatLeaveRequest request = new UserSeatLeaveRequest();
+        request.setUserId(USER_ID);
+        return request;
+    }
+}

--- a/src/test/java/com/example/officenavi/service/UserServiceTest.java
+++ b/src/test/java/com/example/officenavi/service/UserServiceTest.java
@@ -1,0 +1,101 @@
+package com.example.officenavi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.example.officenavi.domain.user.UserEntity;
+import com.example.officenavi.domain.user.UserRegisterRequest;
+import com.example.officenavi.domain.user.UserRegisterResponse;
+import com.example.officenavi.domain.user.UserResponse;
+import com.example.officenavi.repository.UserRepository;
+
+public class UserServiceTest {
+    private static final String NAME = "test user";
+    private static final String EMAIL = "testuser@mail";
+    private static final String PASSWORD = "password";
+
+    
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private UserService userService;
+    
+    @BeforeEach
+    void setup(){
+        userRepository = mock(UserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        userService = new UserService(userRepository, passwordEncoder);
+    }
+    
+    @Test
+    void getUsers_shouldReturnListOfUsers() {
+        when(userRepository.findAll()).thenReturn(List.of(
+            new UserEntity("mike", "mike@mail"),
+            new UserEntity("john", "john@mail")
+        ));
+
+        List<UserResponse> users = userService.getUsers();
+
+        assertEquals(2, users.size());
+        assertEquals("mike", users.get(0).getName());
+        assertEquals("mike@mail", users.get(0).getEmail());
+        assertEquals("john", users.get(1).getName());
+        assertEquals("john@mail", users.get(1).getEmail());
+    }
+    
+    @Test
+    void getUsers_shouldReturnEmptyListWhenNoUsers() {
+        when(userRepository.findAll()).thenReturn(List.of());
+
+        List<UserResponse> users = userService.getUsers();
+
+        assertEquals(0, users.size());
+    }
+    
+    @Test
+    void registerUser_shouldRegisterUser() {
+        when(passwordEncoder.encode(PASSWORD)).thenReturn("hashedPassword");
+        
+        UserRegisterRequest userRegisterRequest = createRegisterRequest();
+        
+        UserEntity createdUserEntity = new UserEntity(NAME, EMAIL, "hashedPassword");
+        createdUserEntity.setId(1);
+        when(userRepository.registerUser(any(UserEntity.class))).thenReturn(createdUserEntity);
+
+        UserRegisterResponse registeredUser = userService.registerUser(userRegisterRequest);
+        
+        assertEquals(1, registeredUser.getId());
+        assertEquals(NAME, registeredUser.getName());
+        assertEquals(EMAIL, registeredUser.getEmail());
+        verify(passwordEncoder).encode(PASSWORD);
+    }
+
+    @Test
+    void registerUser_whenDuplicateEmail_shouldThrowDataIntegrityViolationException() {
+        when(passwordEncoder.encode(PASSWORD)).thenReturn("hashedPassword");
+        
+        UserRegisterRequest userRegisterRequest = createRegisterRequest();
+        
+        when(userRepository.registerUser(any(UserEntity.class))).thenThrow(new DataIntegrityViolationException("Duplicate email"));
+
+        assertThrows(DataIntegrityViolationException.class, () -> userService.registerUser(userRegisterRequest));
+    }
+
+    private UserRegisterRequest createRegisterRequest() {
+        UserRegisterRequest request = new UserRegisterRequest();
+        request.setName(NAME);
+        request.setEmail(EMAIL);
+        request.setPassword(PASSWORD);
+        return request;
+    }
+}


### PR DESCRIPTION
# 概要
- service層の単体テストを追加し、主要な正常系・異常系の振る舞いを検証できるようにしました。
- UserService、SeatService、UserSeatService のテストを整備し、リファクタリングで可読性も統一しました。

# 関連Issue
- Issue: #28 

# 変更内容
- Backend:
  - UserServiceTest を追加し、一覧取得・ユーザー登録・重複メール時の例外を検証
  - SeatServiceTest を追加し、一覧取得の正常系と空配列返却を検証
  - UserSeatServiceTest を追加し、在席登録・退席・現在席取得の正常系/異常系を検証
  - テストコード内の重複を整理し、共通セットアップとリクエスト生成を共通化
- Frontend:
  - なし

# 動作確認内容
1. 手順:
   mvn test -Dtest=SeatServiceTest,UserServiceTest,UserSeatServiceTest
2. 期待結果:
   3つのservice層テストがすべて成功すること
   実行結果: 20 passed / 0 failed

# リスク・影響範囲
- 影響範囲:
  - src/test/java/com/example/officenavi/service 配下のテストコード追加のみ
- 懸念点:
  - 現時点では service層の単体テストのみで、controller/repository 連携の統合観点は別途確認が必要