### PR TITLE
Build setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<build> 
 		<directory>target</directory>
-		<finalName>officenavi-app-sekino</finalName>
+		<finalName>officenavi-app</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
@@ -82,14 +82,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<build> 
+		<directory>target</directory>
+		<finalName>officenavi-app-sekino</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin> 
+		</plugins> 
+	</build>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>


### PR DESCRIPTION
# 概要
- Mavenのbuild設定を整理し、生成物名を明示化しました。
- DB初期化手順を「DB作成」「DDL」「DML」に分離し、初期データ投入スクリプトを追加しました。
- ローカル検証/セットアップ時の再現性向上を目的とした変更です。

# 関連Issue
- Issue: #（未作成の場合は作成後に番号を記載）

# 変更内容
- Backend:
  - Mavenのbuild設定を整理（`finalName` を `officenavi-app` に設定）
- Frontend:
  - 変更なし

# 動作確認内容
1. 手順:
   - アプリをbuildして生成物名を確認
2. 期待結果:
   - build成果物が想定名（officenavi-app）で生成される

# リスク・影響範囲
- 影響範囲:
  - build成果物名に依存する運用手順
- 懸念点:
  - 既存手順で旧ファイル名/旧手順を参照している場合に齟齬が出る可能性