### PR TITLE
feat(frontend): 社員一覧・社員登録画面を実装

### DIFF
--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -1,142 +1,104 @@
 .page {
-  --background: #fafafa;
-  --foreground: #fff;
-
-  --text-primary: #000;
-  --text-secondary: #666;
-
-  --button-primary-hover: #383838;
-  --button-secondary-hover: #f2f2f2;
-  --button-secondary-border: #ebebeb;
-
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--font-geist-sans);
-  background-color: var(--background);
+  display: grid;
+  place-items: center;
+  min-height: 100%;
+  padding: 24px;
+  background:
+    radial-gradient(circle at 15% 20%, #ffd6a5 0%, transparent 40%),
+    radial-gradient(circle at 85% 80%, #bde0fe 0%, transparent 42%),
+    #f8fafc;
 }
 
 .main {
+  width: min(760px, 100%);
+  border-radius: 24px;
+  border: 1px solid #dbe4ee;
+  background: #ffffffcc;
+  backdrop-filter: blur(6px);
+  padding: clamp(24px, 5vw, 48px);
+  box-shadow: 0 24px 50px #00000014;
+  display: grid;
+  gap: 28px;
+}
+
+.hero {
+  display: grid;
+  gap: 14px;
+}
+
+.kicker {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: #3d5972;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  font-size: clamp(28px, 4vw, 44px);
+  line-height: 1.1;
+  color: #10253a;
+}
+
+.hero p {
+  font-size: 16px;
+  line-height: 1.8;
+  color: #334e68;
+}
+
+.actions {
   display: flex;
-  flex: 1;
-  width: 100%;
-  max-width: 800px;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: space-between;
-  background-color: var(--foreground);
-  padding: 120px 60px;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
-.intro {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  text-align: left;
-  gap: 24px;
-}
-
-.intro h1 {
-  max-width: 320px;
-  font-size: 40px;
-  font-weight: 600;
-  line-height: 48px;
-  letter-spacing: -2.4px;
-  text-wrap: balance;
-  color: var(--text-primary);
-}
-
-.intro p {
-  max-width: 440px;
-  font-size: 18px;
-  line-height: 32px;
-  text-wrap: balance;
-  color: var(--text-secondary);
-}
-
-.intro a {
-  font-weight: 500;
-  color: var(--text-primary);
-}
-
-.ctas {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  max-width: 440px;
-  gap: 16px;
-  font-size: 14px;
-}
-
-.ctas a {
-  display: flex;
-  justify-content: center;
+.primary,
+.secondary {
+  height: 42px;
+  display: inline-flex;
   align-items: center;
-  height: 40px;
-  padding: 0 16px;
-  border-radius: 128px;
+  justify-content: center;
+  padding: 0 18px;
+  border-radius: 999px;
   border: 1px solid transparent;
-  transition: 0.2s;
-  cursor: pointer;
-  width: fit-content;
-  font-weight: 500;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
-a.primary {
-  background: var(--text-primary);
-  color: var(--background);
-  gap: 8px;
+.primary {
+  color: #ffffff;
+  background: #1d4e89;
+  box-shadow: 0 10px 24px #1d4e8930;
 }
 
-a.secondary {
-  border-color: var(--button-secondary-border);
+.secondary {
+  color: #1d4e89;
+  background: #eff6ff;
+  border-color: #bfdbfe;
 }
 
-/* Enable hover only on non-touch devices */
 @media (hover: hover) and (pointer: fine) {
-  a.primary:hover {
-    background: var(--button-primary-hover);
-    border-color: transparent;
+  .primary:hover,
+  .secondary:hover {
+    transform: translateY(-1px);
   }
 
-  a.secondary:hover {
-    background: var(--button-secondary-hover);
-    border-color: transparent;
+  .primary:hover {
+    background: #163d6a;
+  }
+
+  .secondary:hover {
+    background: #dbeafe;
   }
 }
 
 @media (max-width: 600px) {
-  .main {
-    padding: 48px 24px;
+  .actions {
+    flex-direction: column;
   }
 
-  .intro {
-    gap: 16px;
-  }
-
-  .intro h1 {
-    font-size: 32px;
-    line-height: 40px;
-    letter-spacing: -1.92px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .logo {
-    filter: invert();
-  }
-
-  .page {
-    --background: #000;
-    --foreground: #000;
-
-    --text-primary: #ededed;
-    --text-secondary: #999;
-
-    --button-primary-hover: #ccc;
-    --button-secondary-hover: #1a1a1a;
-    --button-secondary-border: #1a1a1a;
+  .primary,
+  .secondary {
+    width: 100%;
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,64 +1,26 @@
-import Image from "next/image";
+import Link from "next/link";
 import styles from "./page.module.css";
 
 export default function Home() {
   return (
     <div className={styles.page}>
       <main className={styles.main}>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className={styles.intro}>
-          <h1>To get started, edit the page.tsx file.</h1>
+        <div className={styles.hero}>
+          <p className={styles.kicker}>OfficeNavi</p>
+          <h1>フロント実装をここから開始</h1>
           <p>
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Learning
-            </a>{" "}
-            center.
+            社員一覧の確認と社員登録からMVPを進めます。APIクライアント層を利用して、画面から
+            バックエンドへ接続します。
           </p>
         </div>
-        <div className={styles.ctas}>
-          <a
-            className={styles.primary}
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className={styles.logo}
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className={styles.secondary}
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
+
+        <div className={styles.actions}>
+          <Link className={styles.primary} href="/users">
+            社員一覧を開く
+          </Link>
+          <Link className={styles.secondary} href="/users/new">
+            社員を登録する
+          </Link>
         </div>
       </main>
     </div>

--- a/frontend/src/app/users/new/page.tsx
+++ b/frontend/src/app/users/new/page.tsx
@@ -67,6 +67,11 @@ export default function NewUserPage() {
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
+  const onBlur = (key: keyof UserRegisterRequest) => {
+    const errors = validate(form);
+    setFieldErrors((prev) => ({ ...prev, [key]: errors[key] }));
+  };
+
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -121,6 +126,7 @@ export default function NewUserPage() {
               type="text"
               value={form.name}
               onChange={(e) => onChange("name", e.target.value)}
+              onBlur={() => onBlur("name")}
               placeholder="例: yamada"
               autoComplete="name"
             />
@@ -133,6 +139,7 @@ export default function NewUserPage() {
               type="email"
               value={form.email}
               onChange={(e) => onChange("email", e.target.value)}
+              onBlur={() => onBlur("email")}
               placeholder="example@example.com"
               autoComplete="email"
             />
@@ -145,6 +152,7 @@ export default function NewUserPage() {
               type="password"
               value={form.password}
               onChange={(e) => onChange("password", e.target.value)}
+              onBlur={() => onBlur("password")}
               placeholder="英大文字・英小文字・数字を含む"
               autoComplete="new-password"
             />

--- a/frontend/src/app/users/new/page.tsx
+++ b/frontend/src/app/users/new/page.tsx
@@ -9,38 +9,37 @@ import styles from "./users-new-page.module.css";
 
 type FormErrors = Partial<Record<keyof UserRegisterRequest, string>>;
 
+const NO_WHITESPACE_PATTERN = /^(?!.*[\s　]).+$/;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PASSWORD_PATTERN = /^(?!.*[\s　])(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/;
+
 const validate = (payload: UserRegisterRequest): FormErrors => {
   const errors: FormErrors = {};
-  const hasSpace = (value: string) => /[\s　]/.test(value);
-  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  const passwordPattern = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/;
 
   if (!payload.name) {
     errors.name = "名前は必須です";
   } else if (payload.name.length > 100) {
-    errors.name = "名前は100文字以内で入力してください";
-  } else if (hasSpace(payload.name)) {
-    errors.name = "名前に空白は使用できません";
+    errors.name = "名前は1~100文字以内で入力してください";
+  } else if (!NO_WHITESPACE_PATTERN.test(payload.name)) {
+    errors.name = "名前に空白（半角/全角）は使用できません";
   }
 
   if (!payload.email) {
     errors.email = "メールアドレスは必須です";
   } else if (payload.email.length < 8 || payload.email.length > 255) {
-    errors.email = "メールアドレスは8-255文字で入力してください";
-  } else if (!emailPattern.test(payload.email)) {
-    errors.email = "メールアドレスの形式が不正です";
-  } else if (hasSpace(payload.email)) {
-    errors.email = "メールアドレスに空白は使用できません";
+    errors.email = "メールアドレスは8~255文字以内で入力してください";
+  } else if (!EMAIL_PATTERN.test(payload.email)) {
+    errors.email = "有効なメールアドレスを入力してください";
+  } else if (!NO_WHITESPACE_PATTERN.test(payload.email)) {
+    errors.email = "メールアドレスに空白（半角/全角）は使用できません";
   }
 
   if (!payload.password) {
     errors.password = "パスワードは必須です";
   } else if (payload.password.length < 8 || payload.password.length > 255) {
-    errors.password = "パスワードは8-255文字で入力してください";
-  } else if (hasSpace(payload.password)) {
-    errors.password = "パスワードに空白は使用できません";
-  } else if (!passwordPattern.test(payload.password)) {
-    errors.password = "英大文字・英小文字・数字をそれぞれ1文字以上含めてください";
+    errors.password = "パスワードは8~255文字以内で入力してください";
+  } else if (!PASSWORD_PATTERN.test(payload.password)) {
+    errors.password = "パスワードは空白なしで、大文字・小文字・数字をそれぞれ1文字以上含めてください";
   }
 
   return errors;

--- a/frontend/src/app/users/new/page.tsx
+++ b/frontend/src/app/users/new/page.tsx
@@ -45,6 +45,24 @@ const validate = (payload: UserRegisterRequest): FormErrors => {
   return errors;
 };
 
+const toServerFieldErrors = (err: ApiClientError): FormErrors => {
+  const serverFieldErrors: FormErrors = {};
+
+  for (const item of err.fieldErrors) {
+    if (item.field === "name" || item.field === "email" || item.field === "password") {
+      serverFieldErrors[item.field] = item.message;
+    }
+  }
+
+  for (const item of err.details) {
+    if (item.field === "name" || item.field === "email" || item.field === "password") {
+      serverFieldErrors[item.field] = item.reason;
+    }
+  }
+
+  return serverFieldErrors;
+};
+
 export default function NewUserPage() {
   const router = useRouter();
 
@@ -88,14 +106,14 @@ export default function NewUserPage() {
       router.push("/users");
     } catch (err) {
       if (err instanceof ApiClientError) {
-        const serverFieldErrors: FormErrors = {};
-        for (const item of err.fieldErrors) {
-          if (item.field === "name" || item.field === "email" || item.field === "password") {
-            serverFieldErrors[item.field] = item.message;
-          }
-        }
+        const serverFieldErrors = toServerFieldErrors(err);
         setFieldErrors(serverFieldErrors);
-        setError(err.message || "登録に失敗しました");
+
+        if (Object.keys(serverFieldErrors).length > 0) {
+          setError("");
+        } else {
+          setError(err.message || "登録に失敗しました");
+        }
       } else {
         setError("通信エラーが発生しました");
       }

--- a/frontend/src/app/users/new/page.tsx
+++ b/frontend/src/app/users/new/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ApiClientError, registerUser } from "@/lib/api";
+import type { UserRegisterRequest } from "@/types/api";
+import styles from "./users-new-page.module.css";
+
+type FormErrors = Partial<Record<keyof UserRegisterRequest, string>>;
+
+const validate = (payload: UserRegisterRequest): FormErrors => {
+  const errors: FormErrors = {};
+  const hasSpace = (value: string) => /[\s　]/.test(value);
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const passwordPattern = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/;
+
+  if (!payload.name) {
+    errors.name = "名前は必須です";
+  } else if (payload.name.length > 100) {
+    errors.name = "名前は100文字以内で入力してください";
+  } else if (hasSpace(payload.name)) {
+    errors.name = "名前に空白は使用できません";
+  }
+
+  if (!payload.email) {
+    errors.email = "メールアドレスは必須です";
+  } else if (payload.email.length < 8 || payload.email.length > 255) {
+    errors.email = "メールアドレスは8-255文字で入力してください";
+  } else if (!emailPattern.test(payload.email)) {
+    errors.email = "メールアドレスの形式が不正です";
+  } else if (hasSpace(payload.email)) {
+    errors.email = "メールアドレスに空白は使用できません";
+  }
+
+  if (!payload.password) {
+    errors.password = "パスワードは必須です";
+  } else if (payload.password.length < 8 || payload.password.length > 255) {
+    errors.password = "パスワードは8-255文字で入力してください";
+  } else if (hasSpace(payload.password)) {
+    errors.password = "パスワードに空白は使用できません";
+  } else if (!passwordPattern.test(payload.password)) {
+    errors.password = "英大文字・英小文字・数字をそれぞれ1文字以上含めてください";
+  }
+
+  return errors;
+};
+
+export default function NewUserPage() {
+  const router = useRouter();
+
+  const [form, setForm] = useState<UserRegisterRequest>({
+    name: "",
+    email: "",
+    password: "",
+  });
+  const [fieldErrors, setFieldErrors] = useState<FormErrors>({});
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const hasClientError = useMemo(() => {
+    const errors = validate(form);
+    return Object.keys(errors).length > 0;
+  }, [form]);
+
+  const onChange = (key: keyof UserRegisterRequest, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const errors = validate(form);
+    setFieldErrors(errors);
+    setError("");
+
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await registerUser(form);
+      router.push("/users");
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        const serverFieldErrors: FormErrors = {};
+        for (const item of err.fieldErrors) {
+          if (item.field === "name" || item.field === "email" || item.field === "password") {
+            serverFieldErrors[item.field] = item.message;
+          }
+        }
+        setFieldErrors(serverFieldErrors);
+        setError(err.message || "登録に失敗しました");
+      } else {
+        setError("通信エラーが発生しました");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <header className={styles.header}>
+          <div>
+            <p className={styles.kicker}>New Employee</p>
+            <h1>社員登録</h1>
+          </div>
+          <div className={styles.links}>
+            <Link href="/">トップ</Link>
+            <Link href="/users">社員一覧</Link>
+          </div>
+        </header>
+
+        <form className={styles.form} onSubmit={onSubmit}>
+          <label className={styles.field}>
+            <span>名前</span>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => onChange("name", e.target.value)}
+              placeholder="例: yamada"
+              autoComplete="name"
+            />
+            {fieldErrors.name && <small>{fieldErrors.name}</small>}
+          </label>
+
+          <label className={styles.field}>
+            <span>メールアドレス</span>
+            <input
+              type="email"
+              value={form.email}
+              onChange={(e) => onChange("email", e.target.value)}
+              placeholder="example@example.com"
+              autoComplete="email"
+            />
+            {fieldErrors.email && <small>{fieldErrors.email}</small>}
+          </label>
+
+          <label className={styles.field}>
+            <span>パスワード</span>
+            <input
+              type="password"
+              value={form.password}
+              onChange={(e) => onChange("password", e.target.value)}
+              placeholder="英大文字・英小文字・数字を含む"
+              autoComplete="new-password"
+            />
+            {fieldErrors.password && <small>{fieldErrors.password}</small>}
+          </label>
+
+          {error && <p className={styles.error}>{error}</p>}
+
+          <button type="submit" disabled={submitting || hasClientError}>
+            {submitting ? "登録中..." : "登録する"}
+          </button>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/users/new/users-new-page.module.css
+++ b/frontend/src/app/users/new/users-new-page.module.css
@@ -1,0 +1,120 @@
+.page {
+  min-height: 100%;
+  padding: clamp(16px, 4vw, 28px);
+  background:
+    radial-gradient(circle at 20% 20%, #dbeafe 0%, transparent 40%),
+    radial-gradient(circle at 80% 75%, #fde68a 0%, transparent 42%),
+    #f8fafc;
+}
+
+.main {
+  max-width: 760px;
+  margin: 0 auto;
+  border-radius: 18px;
+  border: 1px solid #d9e2ec;
+  background: #fff;
+  box-shadow: 0 20px 46px #00000010;
+  padding: clamp(18px, 3.5vw, 32px);
+  display: grid;
+  gap: 18px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.kicker {
+  color: #486581;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.header h1 {
+  color: #102a43;
+  font-size: clamp(24px, 3vw, 34px);
+}
+
+.links {
+  display: flex;
+  gap: 8px;
+}
+
+.links a {
+  font-size: 13px;
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  padding: 8px 12px;
+  background: #f8fafc;
+  color: #334e68;
+  font-weight: 600;
+}
+
+.form {
+  display: grid;
+  gap: 14px;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+}
+
+.field span {
+  color: #243b53;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.field input {
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  padding: 11px 12px;
+  font-size: 15px;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px #dbeafe;
+}
+
+.field small {
+  color: #b42318;
+}
+
+.error {
+  color: #b42318;
+  background: #fee4e2;
+  border: 1px solid #fecdca;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.form button {
+  margin-top: 6px;
+  border: 0;
+  border-radius: 10px;
+  background: #1d4ed8;
+  color: #fff;
+  padding: 12px 14px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.form button:disabled {
+  cursor: not-allowed;
+  background: #94a3b8;
+}
+
+@media (max-width: 680px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ApiClientError, getUsers } from "@/lib/api";
+import type { User } from "@/types/api";
+import styles from "./users-page.module.css";
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError("");
+        const data = await getUsers();
+        setUsers(data);
+      } catch (err) {
+        if (err instanceof ApiClientError) {
+          setError(err.message);
+        } else {
+          setError("社員一覧の取得に失敗しました");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void load();
+  }, []);
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <header className={styles.header}>
+          <div>
+            <p className={styles.kicker}>Employees</p>
+            <h1>社員一覧</h1>
+          </div>
+          <div className={styles.links}>
+            <Link href="/">トップ</Link>
+            <Link href="/users/new">新規登録</Link>
+          </div>
+        </header>
+
+        {loading && <p className={styles.message}>読み込み中です...</p>}
+        {!loading && error && <p className={styles.error}>{error}</p>}
+        {!loading && !error && users.length === 0 && (
+          <p className={styles.message}>社員データがありません</p>
+        )}
+
+        {!loading && !error && users.length > 0 && (
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>名前</th>
+                  <th>メールアドレス</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id}>
+                    <td>{user.id}</td>
+                    <td>{user.name}</td>
+                    <td>{user.email}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/users/users-page.module.css
+++ b/frontend/src/app/users/users-page.module.css
@@ -1,0 +1,95 @@
+.page {
+  min-height: 100%;
+  padding: clamp(16px, 4vw, 28px);
+  background: linear-gradient(165deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.main {
+  max-width: 980px;
+  margin: 0 auto;
+  border: 1px solid #d9e2ec;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 18px 44px #00000012;
+  padding: clamp(16px, 3vw, 28px);
+  display: grid;
+  gap: 16px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.kicker {
+  color: #486581;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.header h1 {
+  color: #102a43;
+  font-size: clamp(24px, 3vw, 34px);
+}
+
+.links {
+  display: flex;
+  gap: 8px;
+}
+
+.links a {
+  background: #eff6ff;
+  color: #1d4e89;
+  border: 1px solid #bfdbfe;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  border-bottom: 1px solid #e9eff5;
+  padding: 12px 10px;
+  color: #243b53;
+}
+
+.table th {
+  color: #486581;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.message {
+  color: #486581;
+  padding: 10px 2px;
+}
+
+.error {
+  color: #b42318;
+  background: #fee4e2;
+  border: 1px solid #fecdca;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+@media (max-width: 680px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
# 概要
- 社員一覧画面（`/users`）と社員登録画面（`/users/new`）を実装し、APIクライアント層と接続した
- トップページを OfficeNavi 用の導線画面に刷新した

# 関連Issue
- Issue: #38 

# 変更内容
- Backend:
  - なし
- Frontend:
  - `src/app/page.tsx` / `page.module.css`: トップページをナビゲーション画面に刷新
  - `src/app/users/page.tsx`: 社員一覧画面を新規追加（`getUsers()` でAPI取得・テーブル表示）
  - `src/app/users/new/page.tsx`: 社員登録フォーム画面を新規追加（バリデーション・`registerUser()` 呼び出し）
  - 各画面対応のCSS Modulesを追加

# 動作確認内容
1. 手順: `npm run dev` 起動後、`/`・`/users`・`/users/new` を順に開く
2. 期待結果:
   - `/users` でバックエンドから社員一覧が取得・表示される
   - `/users/new` でフォーム送信後、`/users` にリダイレクトされ登録済み社員が表示される

# リスク・影響範囲
- 影響範囲: フロントエンドのみ（バックエンド変更なし）
- 懸念点: `.env.local` に `NEXT_PUBLIC_API_BASE_URL` の設定が必要（未設定時はエラー表示）