### PR TITLE
fix(backend): CORS設定を外出ししてAPIに限定

### DIFF
--- a/src/main/java/com/example/officenavi/config/SecurityConfig.java
+++ b/src/main/java/com/example/officenavi/config/SecurityConfig.java
@@ -26,6 +26,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> {
+                })
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 
         return http.build();

--- a/src/main/java/com/example/officenavi/config/WebConfig.java
+++ b/src/main/java/com/example/officenavi/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.example.officenavi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final String allowedOrigin;
+
+    public WebConfig(@Value("${app.cors.allowed-origin}") String allowedOrigin) {
+        this.allowedOrigin = allowedOrigin;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(allowedOrigin)
+                .allowedMethods("*")
+                .allowedHeaders("*");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     username: ${OFFICE_NAVI_DB_USER:postgres}
     password: ${OFFICE_NAVI_DB_PASS:postgres}
 
+app:
+  cors:
+    allowed-origin: ${FRONTEND_ORIGIN:http://localhost:3000}
+
 # server:
 #   servlet:
 #     context-path: /office-navi


### PR DESCRIPTION
# 概要
- CORS設定をコード直書きから設定ファイル経由に変更し、環境ごとに許可オリジンを切り替えられるようにした
- CORS適用範囲を API パスに限定して、影響範囲を明確化した

# 関連Issue
- Issue: #45

# 変更内容
- Backend:
  - `SecurityConfig` で CORS を有効化
  - `WebConfig` を追加し、`/api/**` に対する CORS 設定を集約
  - 許可オリジンを `application.yml` の `app.cors.allowed-origin` から読む形に変更
  - 環境変数 `FRONTEND_ORIGIN` 未設定時は `http://localhost:3000` を既定値として使用
- Frontend:
  - なし

# 動作確認内容
1. 手順:
   - バックエンドコードを更新した状態で `./mvnw -q -DskipTests compile` を実行する
   - フロントエンドを `http://localhost:3000` で起動する
   - フロントエンドから `/api/users` などのAPIを呼び出す
2. 期待結果:
   - バックエンドが正常にコンパイルできる
   - `http://localhost:3000` からの API リクエストが CORS エラーにならない
   - CORS 設定の適用範囲が `/api/**` に限定されている

# リスク・影響範囲
- 影響範囲:
  - バックエンドの Web / Security 設定
  - フロントエンドからバックエンドへの API 通信
- 懸念点:
  - 本番環境では `FRONTEND_ORIGIN` の設定漏れがあると意図したオリジンから接続できない