### PR TITLE
fix(frontend): 社員登録フォームのエラー表示を改善

### DIFF
--- a/frontend/src/app/users/new/page.tsx
+++ b/frontend/src/app/users/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiClientError, registerUser } from "@/lib/api";
@@ -65,6 +65,7 @@ const toServerFieldErrors = (err: ApiClientError): FormErrors => {
 
 export default function NewUserPage() {
   const router = useRouter();
+  const emailInputRef = useRef<HTMLInputElement | null>(null);
 
   const [form, setForm] = useState<UserRegisterRequest>({
     name: "",
@@ -82,10 +83,26 @@ export default function NewUserPage() {
 
   const onChange = (key: keyof UserRegisterRequest, value: string) => {
     setForm((prev) => ({ ...prev, [key]: value }));
+
+    if (key === "email") {
+      setFieldErrors((prev) => ({
+        ...prev,
+        email: validate({ ...form, email: value }).email,
+      }));
+    }
   };
 
   const onBlur = (key: keyof UserRegisterRequest) => {
     const errors = validate(form);
+
+    if (key === "email") {
+      setFieldErrors((prev) => ({
+        ...prev,
+        email: errors.email,
+      }));
+      return;
+    }
+
     setFieldErrors((prev) => ({ ...prev, [key]: errors[key] }));
   };
 
@@ -108,6 +125,12 @@ export default function NewUserPage() {
       if (err instanceof ApiClientError) {
         const serverFieldErrors = toServerFieldErrors(err);
         setFieldErrors(serverFieldErrors);
+
+        if (serverFieldErrors.email) {
+          requestAnimationFrame(() => {
+            emailInputRef.current?.focus();
+          });
+        }
 
         if (Object.keys(serverFieldErrors).length > 0) {
           setError("");
@@ -136,7 +159,7 @@ export default function NewUserPage() {
           </div>
         </header>
 
-        <form className={styles.form} onSubmit={onSubmit}>
+        <form className={styles.form} onSubmit={onSubmit} noValidate>
           <label className={styles.field}>
             <span>名前</span>
             <input
@@ -153,6 +176,7 @@ export default function NewUserPage() {
           <label className={styles.field}>
             <span>メールアドレス</span>
             <input
+              ref={emailInputRef}
               type="email"
               value={form.email}
               onChange={(e) => onChange("email", e.target.value)}


### PR DESCRIPTION
# 概要
- 社員登録フォームのエラー表示を改善し、入力ミスや重複メール時にユーザーが修正箇所を把握しやすいようにした

# 関連Issue
- Issue: #

# 変更内容
- Backend:
  - なし
- Frontend:
  - 社員登録フォームでメールアドレス入力時のバリデーション表示を即時反映するように変更
  - サーバーからメールアドレスのフィールドエラーが返った場合、メール入力欄に自動でフォーカスを戻すように変更
  - フォームに `noValidate` を追加し、ブラウザ標準のバリデーションではなく画面側のエラー表示を優先するように変更

# 動作確認内容
1. 手順:
   - フロントエンドを起動して `/users/new` を開く
   - 不正なメールアドレス形式を入力して表示内容を確認する
   - 既に登録済みのメールアドレスで登録を実行する
2. 期待結果:
   - メールアドレス形式エラーがフォーム上に表示される
   - 重複メールで登録失敗した場合、メールアドレス欄に inline エラーが表示され、フォーカスがメール欄へ戻る
   - フィールドエラーがある場合に英語の汎用メッセージは表示されない

# リスク・影響範囲
- 影響範囲:
  - 社員登録画面の入力体験
- 懸念点:
  - メール形式チェックはフロント独自の正規表現を使っているため、バックエンドの `@Email` と完全一致ではない