### PR TITLE
feat: 現在位置照会画面と照会APIを実装

### DIFF
--- a/frontend/src/app/current-seat-lookup/current-seat-lookup-page.module.css
+++ b/frontend/src/app/current-seat-lookup/current-seat-lookup-page.module.css
@@ -1,0 +1,216 @@
+.page {
+  min-height: 100%;
+  padding: clamp(16px, 4vw, 28px);
+  background:
+    radial-gradient(circle at 12% 18%, #dbeafe 0%, transparent 40%),
+    radial-gradient(circle at 86% 82%, #cffafe 0%, transparent 38%),
+    #f8fafc;
+}
+
+.main {
+  max-width: 860px;
+  margin: 0 auto;
+  border-radius: 18px;
+  border: 1px solid #d9e2ec;
+  background: #fff;
+  box-shadow: 0 18px 44px #00000012;
+  padding: clamp(18px, 3vw, 30px);
+  display: grid;
+  gap: 16px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.kicker {
+  color: #486581;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.header h1 {
+  color: #102a43;
+  font-size: clamp(24px, 3vw, 34px);
+}
+
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.links a {
+  background: #ecfeff;
+  color: #155e75;
+  border: 1px solid #a5f3fc;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.panel {
+  border: 1px solid #e4ecf5;
+  border-radius: 14px;
+  padding: clamp(12px, 2.4vw, 18px);
+}
+
+.form {
+  display: flex;
+  gap: 10px;
+  align-items: end;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+  flex: 1;
+}
+
+.field span {
+  color: #243b53;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.field input {
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  padding: 11px 12px;
+  font-size: 15px;
+  color: #102a43;
+  background: #fff;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: #0f766e;
+  box-shadow: 0 0 0 3px #ccfbf1;
+}
+
+.primary,
+.retry {
+  border: 0;
+  border-radius: 10px;
+  padding: 11px 14px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.primary {
+  background: #0f766e;
+  color: #fff;
+  min-width: 110px;
+}
+
+.retry {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.primary:disabled,
+.retry:disabled {
+  background: #cbd5e1;
+  color: #64748b;
+  cursor: not-allowed;
+}
+
+.card {
+  border: 1px solid #dbe7f3;
+  border-radius: 14px;
+  padding: clamp(12px, 2.3vw, 18px);
+  display: grid;
+  gap: 10px;
+  background: #f8fafc;
+}
+
+.results {
+  display: grid;
+  gap: 10px;
+}
+
+.results h2 {
+  color: #102a43;
+  font-size: 18px;
+}
+
+.cards {
+  display: grid;
+  gap: 10px;
+}
+
+.card h2 {
+  color: #102a43;
+  font-size: 18px;
+}
+
+.card dl {
+  display: grid;
+  gap: 8px;
+}
+
+.card dl div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.card dt {
+  min-width: 90px;
+  color: #486581;
+  font-weight: 700;
+}
+
+.card dd {
+  margin: 0;
+  color: #102a43;
+}
+
+.empty {
+  color: #486581;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #f8fafc;
+}
+
+.errorBox {
+  border-radius: 10px;
+  padding: 10px 12px;
+  border: 1px solid #fecdca;
+  background: #fee4e2;
+  color: #b42318;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+@media (max-width: 680px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primary,
+  .retry {
+    width: 100%;
+  }
+
+  .errorBox {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/frontend/src/app/current-seat-lookup/page.tsx
+++ b/frontend/src/app/current-seat-lookup/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useEffect } from "react";
+import { ApiClientError, getAllCurrentSeats, getCurrentSeatByUserId } from "@/lib/api";
+import type { CurrentSeat } from "@/types/api";
+import styles from "./current-seat-lookup-page.module.css";
+
+const isPositiveInteger = (value: string) => {
+  return /^[1-9][0-9]*$/.test(value);
+};
+
+export default function CurrentSeatLookupPage() {
+  const [userIdInput, setUserIdInput] = useState("");
+  const [submittedUserId, setSubmittedUserId] = useState<number | null>(null);
+  const [results, setResults] = useState<CurrentSeat[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [emptyMessage, setEmptyMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const clearMessages = () => {
+    setEmptyMessage("");
+    setErrorMessage("");
+  };
+
+  const lookupAll = async () => {
+    clearMessages();
+    setSubmittedUserId(null);
+    setLoading(true);
+
+    try {
+      const data = await getAllCurrentSeats();
+      setResults(data);
+      if (data.length === 0) {
+        setEmptyMessage("現在座席が登録されているユーザーはいません。");
+      }
+    } catch (err) {
+      setResults([]);
+      if (err instanceof ApiClientError && err.status >= 500) {
+        setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
+      } else if (err instanceof ApiClientError) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage("現在位置の照会に失敗しました。");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const lookupByUserId = async (userId: number) => {
+    clearMessages();
+    setResults([]);
+    setSubmittedUserId(userId);
+    setLoading(true);
+
+    try {
+      const data = await getCurrentSeatByUserId(userId);
+      setResults([data]);
+    } catch (err) {
+      if (err instanceof ApiClientError && err.status === 404) {
+        setEmptyMessage(`userId=${userId} の現在位置は登録されていません。`);
+      } else if (err instanceof ApiClientError && err.status >= 500) {
+        setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
+      } else if (err instanceof ApiClientError) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage("現在位置の照会に失敗しました。");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const loadInitial = async () => {
+      clearMessages();
+      setSubmittedUserId(null);
+      setLoading(true);
+
+      try {
+        const data = await getAllCurrentSeats();
+        setResults(data);
+        if (data.length === 0) {
+          setEmptyMessage("現在座席が登録されているユーザーはいません。");
+        }
+      } catch (err) {
+        setResults([]);
+        if (err instanceof ApiClientError && err.status >= 500) {
+          setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
+        } else if (err instanceof ApiClientError) {
+          setErrorMessage(err.message);
+        } else {
+          setErrorMessage("現在位置の照会に失敗しました。");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void loadInitial();
+  }, []);
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!userIdInput) {
+      await lookupAll();
+      return;
+    }
+
+    if (!isPositiveInteger(userIdInput)) {
+      clearMessages();
+      setResults([]);
+      setErrorMessage("社員IDは1以上の整数を入力してください。");
+      return;
+    }
+
+    await lookupByUserId(Number(userIdInput));
+  };
+
+  const onRetry = async () => {
+    if (loading) {
+      return;
+    }
+
+    if (submittedUserId === null) {
+      await lookupAll();
+      return;
+    }
+
+    await lookupByUserId(submittedUserId);
+  };
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <header className={styles.header}>
+          <div>
+            <p className={styles.kicker}>Current Seat Lookup</p>
+            <h1>現在位置照会</h1>
+          </div>
+        </header>
+
+        <section className={styles.panel}>
+          <form className={styles.form} onSubmit={onSubmit}>
+            <label className={styles.field}>
+              <span>社員ID</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                placeholder="空欄で全件（例: 1）"
+                value={userIdInput}
+                onChange={(e) => setUserIdInput(e.target.value.trim())}
+                disabled={loading}
+              />
+            </label>
+            <button type="submit" className={styles.primary} disabled={loading}>
+              {loading ? "照会中..." : "照会"}
+            </button>
+          </form>
+        </section>
+
+        {errorMessage && (
+          <section className={styles.errorBox}>
+            <p>{errorMessage}</p>
+            {submittedUserId !== null && (
+              <button type="button" className={styles.retry} onClick={onRetry} disabled={loading}>
+                再試行
+              </button>
+            )}
+          </section>
+        )}
+
+        {emptyMessage && <p className={styles.empty}>{emptyMessage}</p>}
+
+        {results.length > 0 && (
+          <section className={styles.results}>
+            <h2>照会結果</h2>
+            <div className={styles.cards}>
+              {results.map((result) => (
+                <article className={styles.card} key={`${result.userId}-${result.seat.id}-${result.since}`}>
+                  <dl>
+                    <div>
+                      <dt>社員ID</dt>
+                      <dd>{result.userId}</dd>
+                    </div>
+                    <div>
+                      <dt>社員名</dt>
+                      <dd>{result.userName}</dd>
+                    </div>
+                    <div>
+                      <dt>座席</dt>
+                      <dd>{result.seat.name}</dd>
+                    </div>
+                    <div>
+                      <dt>場所</dt>
+                      <dd>{result.seat.location || "location未設定"}</dd>
+                    </div>
+                    <div>
+                      <dt>着席開始</dt>
+                      <dd>{new Date(result.since).toLocaleString("ja-JP")}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,5 +1,11 @@
 export { login, logout } from "@/lib/api/auth";
 export { ApiClientError, apiRequest } from "@/lib/api/client";
 export { getSeats } from "@/lib/api/seats";
-export { getCurrentSeat, leaveCurrentSeat, registerCurrentSeat } from "@/lib/api/user-seats";
+export {
+	getAllCurrentSeats,
+	getCurrentSeat,
+	getCurrentSeatByUserId,
+	leaveCurrentSeat,
+	registerCurrentSeat,
+} from "@/lib/api/user-seats";
 export { getUsers, registerUser } from "@/lib/api/users";

--- a/frontend/src/lib/api/user-seats.ts
+++ b/frontend/src/lib/api/user-seats.ts
@@ -22,3 +22,11 @@ export const leaveCurrentSeat = async () => {
 export const getCurrentSeat = async () => {
   return apiRequest<CurrentSeat>("/users/me/current-seat");
 };
+
+export const getCurrentSeatByUserId = async (userId: number) => {
+  return apiRequest<CurrentSeat>(`/users/${userId}/current-seat`);
+};
+
+export const getAllCurrentSeats = async () => {
+  return apiRequest<CurrentSeat[]>("/users/current-seats");
+};

--- a/src/main/java/com/example/officenavi/controller/UserSeatController.java
+++ b/src/main/java/com/example/officenavi/controller/UserSeatController.java
@@ -11,10 +11,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * 在席情報関連APIを提供するコントローラーです。
@@ -71,6 +74,29 @@ public class UserSeatController {
     public ResponseEntity<UserCurrentSeatResponse> getCurrentSeat(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
         UserCurrentSeatResponse response = userSeatService.getCurrentSeat(authenticatedUser.userId());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 指定ユーザーの現在位置を取得します。
+     *
+     * @param userId ユーザーID
+     * @return 200 OK（現在位置情報）
+     */
+    @GetMapping("/users/{userId}/current-seat")
+    public ResponseEntity<UserCurrentSeatResponse> getCurrentSeatByUserId(@PathVariable Integer userId) {
+        UserCurrentSeatResponse response = userSeatService.getCurrentSeat(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 現在在席中のユーザー一覧を取得します。
+     *
+     * @return 200 OK（現在位置情報一覧）
+     */
+    @GetMapping("/users/current-seats")
+    public ResponseEntity<List<UserCurrentSeatResponse>> getAllCurrentSeats() {
+        List<UserCurrentSeatResponse> response = userSeatService.getAllCurrentSeats();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,21 +18,20 @@ import java.util.Optional;
 @Repository
 public class UserSeatRepository {
 
-    private static final RowMapper<UserCurrentSeatEntity> USER_CURRENT_SEAT_ROW_MAPPER = (rs, rowNum) -> new UserCurrentSeatEntity(
-            rs.getInt("user_id"),
-            rs.getString("user_name"),
-            rs.getInt("seat_id"),
-            rs.getString("seat_name"),
-            rs.getString("seat_location"),
-            rs.getTimestamp("since").toLocalDateTime()
-    );
+    private static final RowMapper<UserCurrentSeatEntity> USER_CURRENT_SEAT_ROW_MAPPER = (rs,
+            rowNum) -> new UserCurrentSeatEntity(
+                    rs.getInt("user_id"),
+                    rs.getString("user_name"),
+                    rs.getInt("seat_id"),
+                    rs.getString("seat_name"),
+                    rs.getString("seat_location"),
+                    rs.getTimestamp("since").toLocalDateTime());
 
     private static final RowMapper<UserSeatEntity> USER_SEAT_ROW_MAPPER = (rs, rowNum) -> new UserSeatEntity(
             rs.getInt("id"),
             rs.getInt("user_id"),
             rs.getInt("seat_id"),
-            rs.getTimestamp("start_time").toLocalDateTime()
-    );
+            rs.getTimestamp("start_time").toLocalDateTime());
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -180,5 +180,28 @@ public class UserSeatRepository {
                 """;
         SqlParameterSource param = new MapSqlParameterSource().addValue("userId", userId);
         return jdbcTemplate.query(sql, param, USER_CURRENT_SEAT_ROW_MAPPER).stream().findFirst();
+    }
+
+    /**
+     * 現在在席中のユーザーを全件取得します。
+     *
+     * @return 現在位置情報一覧
+     */
+    public List<UserCurrentSeatEntity> findAllCurrentSeats() {
+        String sql = """
+                SELECT
+                    u.id AS user_id,
+                    u.name AS user_name,
+                    s.id AS seat_id,
+                    s.name AS seat_name,
+                    s.location AS seat_location,
+                    us.start_time AS since
+                FROM user_seats us
+                INNER JOIN users u ON u.id = us.user_id
+                INNER JOIN seats s ON s.id = us.seat_id
+                WHERE us.end_time IS NULL
+                ORDER BY u.id ASC
+                """;
+        return jdbcTemplate.query(sql, USER_CURRENT_SEAT_ROW_MAPPER);
     }
 }

--- a/src/main/java/com/example/officenavi/service/UserSeatService.java
+++ b/src/main/java/com/example/officenavi/service/UserSeatService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 在席情報の業務ロジックを扱うサービスです。
@@ -99,6 +100,21 @@ public class UserSeatService {
                         "CURRENT_SEAT_NOT_FOUND",
                         "対象ユーザーの現在位置が登録されていません"));
 
+        return toResponse(entity);
+    }
+
+    /**
+     * 現在在席中のユーザー一覧を取得します。
+     *
+     * @return 現在位置取得レスポンス一覧
+     */
+    public List<UserCurrentSeatResponse> getAllCurrentSeats() {
+        return userSeatRepository.findAllCurrentSeats().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private UserCurrentSeatResponse toResponse(UserCurrentSeatEntity entity) {
         return new UserCurrentSeatResponse(
                 entity.getUserId(),
                 entity.getUserName(),

--- a/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
@@ -138,6 +138,57 @@ class UserSeatControllerTest {
         }
 
         @Test
+        void getCurrentSeatByUserId_shouldReturn200() throws Exception {
+                UserCurrentSeatResponse response = new UserCurrentSeatResponse(
+                                5,
+                                "佐藤花子",
+                                new UserCurrentSeatResponse.SeatInfo(20, "B-20", "4F West"),
+                                LocalDateTime.of(2026, 3, 24, 9, 0, 0));
+                when(userSeatService.getCurrentSeat(5)).thenReturn(response);
+
+                mockMvc.perform(get("/api/users/5/current-seat")
+                                .with(loginAs(1)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.userId").value(5))
+                                .andExpect(jsonPath("$.userName").value("佐藤花子"))
+                                .andExpect(jsonPath("$.seat.id").value(20));
+        }
+
+        @Test
+        void getCurrentSeatByUserId_whenNotFound_shouldReturn404() throws Exception {
+                when(userSeatService.getCurrentSeat(404))
+                                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND",
+                                                "対象ユーザーの現在位置が登録されていません"));
+
+                mockMvc.perform(get("/api/users/404/current-seat")
+                                .with(loginAs(1)))
+                                .andExpect(status().isNotFound())
+                                .andExpect(jsonPath("$.code").value("CURRENT_SEAT_NOT_FOUND"));
+        }
+
+        @Test
+        void getAllCurrentSeats_shouldReturn200() throws Exception {
+                when(userSeatService.getAllCurrentSeats()).thenReturn(List.of(
+                                new UserCurrentSeatResponse(
+                                                1,
+                                                "山田太郎",
+                                                new UserCurrentSeatResponse.SeatInfo(10, "A-01", "3F East"),
+                                                LocalDateTime.of(2026, 3, 24, 9, 0, 0)),
+                                new UserCurrentSeatResponse(
+                                                2,
+                                                "佐藤花子",
+                                                new UserCurrentSeatResponse.SeatInfo(20, "B-10", "4F West"),
+                                                LocalDateTime.of(2026, 3, 24, 9, 15, 0))));
+
+                mockMvc.perform(get("/api/users/current-seats")
+                                .with(loginAs(1)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].userId").value(1))
+                                .andExpect(jsonPath("$[0].seat.id").value(10))
+                                .andExpect(jsonPath("$[1].userId").value(2));
+        }
+
+        @Test
         void registerCurrentSeat_whenUserNotFound_shouldReturn404() throws Exception {
                 when(userSeatService.registerCurrentSeat(anyInt(), anyInt()))
                                 .thenThrow(new ResourceNotFoundException("USER_NOT_FOUND", "指定されたuserIdは存在しません"));


### PR DESCRIPTION
# 概要
- 現在位置照会画面を新規実装しました。
- 全件照会と社員ID指定照会を可能にし、表示分岐（200/404/500）を明確化しました。

# 関連Issue
- Issue: #50 

# 変更内容
- Backend:
  - GET /api/users/current-seats を追加
  - GET /api/users/{userId}/current-seat を利用した照会処理を整備
  - UserSeatService / UserSeatRepository に現在在席一覧取得処理を追加
  - UserSeatControllerTest に照会系テストを追加
- Frontend:
  - 現在位置照会画面を追加
  - 画面初期表示で全件取得
  - 社員ID未入力で照会時は全件検索
  - 社員ID入力時は対象ユーザーを照会
  - 404時は対象なしメッセージ、500時は再試行導線を表示
- Infra/Config:
  - 変更なし

# 動作確認内容
1. 手順:
   - 現在位置照会画面を開く
   - 社員ID未入力で照会
   - 存在する社員IDで照会
   - 存在しない社員IDで照会
2. 期待結果:
   - 初期表示と未入力照会で全件表示される
   - 存在IDで照会結果が表示される
   - 非存在IDで対象なし表示になる
   - サーバーエラー時に再試行導線が表示される

# リスク・影響範囲
- 影響範囲:
  - 在席照会APIおよび現在位置照会画面
- 懸念点:
  - 在席データ件数増加時の全件表示パフォーマンス