### PR TITLE
Feature/global header navigation

### DIFF
--- a/frontend/src/app/current-seat-lookup/current-seat-lookup-page.module.css
+++ b/frontend/src/app/current-seat-lookup/current-seat-lookup-page.module.css
@@ -1,0 +1,216 @@
+.page {
+  min-height: 100%;
+  padding: clamp(16px, 4vw, 28px);
+  background:
+    radial-gradient(circle at 12% 18%, #dbeafe 0%, transparent 40%),
+    radial-gradient(circle at 86% 82%, #cffafe 0%, transparent 38%),
+    #f8fafc;
+}
+
+.main {
+  max-width: 860px;
+  margin: 0 auto;
+  border-radius: 18px;
+  border: 1px solid #d9e2ec;
+  background: #fff;
+  box-shadow: 0 18px 44px #00000012;
+  padding: clamp(18px, 3vw, 30px);
+  display: grid;
+  gap: 16px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.kicker {
+  color: #486581;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.header h1 {
+  color: #102a43;
+  font-size: clamp(24px, 3vw, 34px);
+}
+
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.links a {
+  background: #ecfeff;
+  color: #155e75;
+  border: 1px solid #a5f3fc;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.panel {
+  border: 1px solid #e4ecf5;
+  border-radius: 14px;
+  padding: clamp(12px, 2.4vw, 18px);
+}
+
+.form {
+  display: flex;
+  gap: 10px;
+  align-items: end;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+  flex: 1;
+}
+
+.field span {
+  color: #243b53;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.field input {
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  padding: 11px 12px;
+  font-size: 15px;
+  color: #102a43;
+  background: #fff;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: #0f766e;
+  box-shadow: 0 0 0 3px #ccfbf1;
+}
+
+.primary,
+.retry {
+  border: 0;
+  border-radius: 10px;
+  padding: 11px 14px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.primary {
+  background: #0f766e;
+  color: #fff;
+  min-width: 110px;
+}
+
+.retry {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.primary:disabled,
+.retry:disabled {
+  background: #cbd5e1;
+  color: #64748b;
+  cursor: not-allowed;
+}
+
+.card {
+  border: 1px solid #dbe7f3;
+  border-radius: 14px;
+  padding: clamp(12px, 2.3vw, 18px);
+  display: grid;
+  gap: 10px;
+  background: #f8fafc;
+}
+
+.results {
+  display: grid;
+  gap: 10px;
+}
+
+.results h2 {
+  color: #102a43;
+  font-size: 18px;
+}
+
+.cards {
+  display: grid;
+  gap: 10px;
+}
+
+.card h2 {
+  color: #102a43;
+  font-size: 18px;
+}
+
+.card dl {
+  display: grid;
+  gap: 8px;
+}
+
+.card dl div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.card dt {
+  min-width: 90px;
+  color: #486581;
+  font-weight: 700;
+}
+
+.card dd {
+  margin: 0;
+  color: #102a43;
+}
+
+.empty {
+  color: #486581;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #f8fafc;
+}
+
+.errorBox {
+  border-radius: 10px;
+  padding: 10px 12px;
+  border: 1px solid #fecdca;
+  background: #fee4e2;
+  color: #b42318;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+@media (max-width: 680px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primary,
+  .retry {
+    width: 100%;
+  }
+
+  .errorBox {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/frontend/src/app/current-seat-lookup/page.tsx
+++ b/frontend/src/app/current-seat-lookup/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useEffect } from "react";
+import { ApiClientError, getAllCurrentSeats, getCurrentSeatByUserId } from "@/lib/api";
+import type { CurrentSeat } from "@/types/api";
+import styles from "./current-seat-lookup-page.module.css";
+
+const isPositiveInteger = (value: string) => {
+  return /^[1-9][0-9]*$/.test(value);
+};
+
+export default function CurrentSeatLookupPage() {
+  const [userIdInput, setUserIdInput] = useState("");
+  const [submittedUserId, setSubmittedUserId] = useState<number | null>(null);
+  const [results, setResults] = useState<CurrentSeat[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [emptyMessage, setEmptyMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const clearMessages = () => {
+    setEmptyMessage("");
+    setErrorMessage("");
+  };
+
+  const lookupAll = async () => {
+    clearMessages();
+    setSubmittedUserId(null);
+    setLoading(true);
+
+    try {
+      const data = await getAllCurrentSeats();
+      setResults(data);
+      if (data.length === 0) {
+        setEmptyMessage("現在座席が登録されているユーザーはいません。");
+      }
+    } catch (err) {
+      setResults([]);
+      if (err instanceof ApiClientError && err.status >= 500) {
+        setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
+      } else if (err instanceof ApiClientError) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage("現在位置の照会に失敗しました。");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const lookupByUserId = async (userId: number) => {
+    clearMessages();
+    setResults([]);
+    setSubmittedUserId(userId);
+    setLoading(true);
+
+    try {
+      const data = await getCurrentSeatByUserId(userId);
+      setResults([data]);
+    } catch (err) {
+      if (err instanceof ApiClientError && err.status === 404) {
+        setEmptyMessage(`userId=${userId} の現在位置は登録されていません。`);
+      } else if (err instanceof ApiClientError && err.status >= 500) {
+        setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
+      } else if (err instanceof ApiClientError) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage("現在位置の照会に失敗しました。");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const loadInitial = async () => {
+      clearMessages();
+      setSubmittedUserId(null);
+      setLoading(true);
+
+      try {
+        const data = await getAllCurrentSeats();
+        setResults(data);
+        if (data.length === 0) {
+          setEmptyMessage("現在座席が登録されているユーザーはいません。");
+        }
+      } catch (err) {
+        setResults([]);
+        if (err instanceof ApiClientError && err.status >= 500) {
+          setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
+        } else if (err instanceof ApiClientError) {
+          setErrorMessage(err.message);
+        } else {
+          setErrorMessage("現在位置の照会に失敗しました。");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void loadInitial();
+  }, []);
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!userIdInput) {
+      await lookupAll();
+      return;
+    }
+
+    if (!isPositiveInteger(userIdInput)) {
+      clearMessages();
+      setResults([]);
+      setErrorMessage("社員IDは1以上の整数を入力してください。");
+      return;
+    }
+
+    await lookupByUserId(Number(userIdInput));
+  };
+
+  const onRetry = async () => {
+    if (loading) {
+      return;
+    }
+
+    if (submittedUserId === null) {
+      await lookupAll();
+      return;
+    }
+
+    await lookupByUserId(submittedUserId);
+  };
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <header className={styles.header}>
+          <div>
+            <p className={styles.kicker}>Current Seat Lookup</p>
+            <h1>現在位置照会</h1>
+          </div>
+        </header>
+
+        <section className={styles.panel}>
+          <form className={styles.form} onSubmit={onSubmit}>
+            <label className={styles.field}>
+              <span>社員ID</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                placeholder="空欄で全件（例: 1）"
+                value={userIdInput}
+                onChange={(e) => setUserIdInput(e.target.value.trim())}
+                disabled={loading}
+              />
+            </label>
+            <button type="submit" className={styles.primary} disabled={loading}>
+              {loading ? "照会中..." : "照会"}
+            </button>
+          </form>
+        </section>
+
+        {errorMessage && (
+          <section className={styles.errorBox}>
+            <p>{errorMessage}</p>
+            {submittedUserId !== null && (
+              <button type="button" className={styles.retry} onClick={onRetry} disabled={loading}>
+                再試行
+              </button>
+            )}
+          </section>
+        )}
+
+        {emptyMessage && <p className={styles.empty}>{emptyMessage}</p>}
+
+        {results.length > 0 && (
+          <section className={styles.results}>
+            <h2>照会結果</h2>
+            <div className={styles.cards}>
+              {results.map((result) => (
+                <article className={styles.card} key={`${result.userId}-${result.seat.id}-${result.since}`}>
+                  <dl>
+                    <div>
+                      <dt>社員ID</dt>
+                      <dd>{result.userId}</dd>
+                    </div>
+                    <div>
+                      <dt>社員名</dt>
+                      <dd>{result.userName}</dd>
+                    </div>
+                    <div>
+                      <dt>座席</dt>
+                      <dd>{result.seat.name}</dd>
+                    </div>
+                    <div>
+                      <dt>場所</dt>
+                      <dd>{result.seat.location || "location未設定"}</dd>
+                    </div>
+                    <div>
+                      <dt>着席開始</dt>
+                      <dd>{new Date(result.since).toLocaleString("ja-JP")}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import GlobalHeaderNav from "@/components/global-header-nav";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,7 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className={`${geistSans.variable} ${geistMono.variable}`}>
-      <body>{children}</body>
+      <body>
+        <GlobalHeaderNav />
+        {children}
+      </body>
     </html>
   );
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiClientError, login } from "@/lib/api";
 import { hasAccessToken } from "@/lib/api/client";
@@ -52,9 +51,6 @@ export default function LoginPage() {
             <p className={styles.kicker}>OfficeNavi Auth</p>
             <h1>ログイン</h1>
           </div>
-          <Link href="/" className={styles.backLink}>
-            トップへ戻る
-          </Link>
         </header>
 
         <form className={styles.form} onSubmit={onSubmit} noValidate>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,32 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { logout } from "@/lib/api";
-import { hasAccessToken } from "@/lib/api/client";
 import styles from "./page.module.css";
 
 export default function Home() {
-  const router = useRouter();
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    const frameId = requestAnimationFrame(() => {
-      setIsLoggedIn(hasAccessToken());
-    });
-
-    return () => {
-      cancelAnimationFrame(frameId);
-    };
-  }, []);
-
-  const onLogout = () => {
-    logout();
-    setIsLoggedIn(false);
-    router.push("/login");
-  };
-
   return (
     <div className={styles.page}>
       <main className={styles.main}>
@@ -37,28 +13,6 @@ export default function Home() {
             社員一覧の確認と社員登録からMVPを進めます。APIクライアント層を利用して、画面から
             バックエンドへ接続します。
           </p>
-        </div>
-
-        <div className={styles.actions}>
-          {!isLoggedIn && (
-            <Link className={styles.primary} href="/login">
-              ログイン
-            </Link>
-          )}
-          {isLoggedIn && (
-            <button type="button" className={styles.secondary} onClick={onLogout}>
-              ログアウト
-            </button>
-          )}
-          <Link className={styles.primary} href="/users">
-            社員一覧を開く
-          </Link>
-          <Link className={styles.secondary} href="/users/new">
-            社員を登録する
-          </Link>
-          <Link className={styles.secondary} href="/seat-actions">
-            座席登録・退席
-          </Link>
         </div>
       </main>
     </div>

--- a/frontend/src/app/seat-actions/page.tsx
+++ b/frontend/src/app/seat-actions/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import {
   ApiClientError,
   getCurrentSeat,
@@ -142,10 +141,6 @@ export default function SeatActionsPage() {
           <div>
             <p className={styles.kicker}>Seat Actions</p>
             <h1>座席登録・退席</h1>
-          </div>
-          <div className={styles.links}>
-            <Link href="/">トップ</Link>
-            <Link href="/users">社員一覧</Link>
           </div>
         </header>
 

--- a/frontend/src/app/users/new/page.tsx
+++ b/frontend/src/app/users/new/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ApiClientError, logout, registerUser } from "@/lib/api";
+import { ApiClientError, registerUser } from "@/lib/api";
 import { hasAccessToken } from "@/lib/api/client";
 import type { UserRegisterRequest } from "@/types/api";
 import styles from "./users-new-page.module.css";
@@ -67,7 +66,6 @@ const toServerFieldErrors = (err: ApiClientError): FormErrors => {
 export default function NewUserPage() {
   const router = useRouter();
   const emailInputRef = useRef<HTMLInputElement | null>(null);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const [form, setForm] = useState<UserRegisterRequest>({
     name: "",
@@ -80,18 +78,11 @@ export default function NewUserPage() {
 
   useEffect(() => {
     const loggedIn = hasAccessToken();
-    setIsLoggedIn(loggedIn);
 
     if (!loggedIn) {
       router.replace("/login");
     }
   }, [router]);
-
-  const onLogout = () => {
-    logout();
-    setIsLoggedIn(false);
-    router.push("/login");
-  };
 
   const hasClientError = useMemo(() => {
     const errors = validate(form);
@@ -169,17 +160,6 @@ export default function NewUserPage() {
           <div>
             <p className={styles.kicker}>New Employee</p>
             <h1>社員登録</h1>
-          </div>
-          <div className={styles.links}>
-            <Link href="/">トップ</Link>
-            <Link href="/users">社員一覧</Link>
-            {!isLoggedIn && <Link href="/login">ログイン</Link>}
-            {isLoggedIn && (
-              <button type="button" onClick={onLogout}>
-                ログアウト
-              </button>
-            )}
-            <Link href="/seat-actions">座席操作</Link>
           </div>
         </header>
 

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -1,23 +1,20 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ApiClientError, getUsers, logout } from "@/lib/api";
+import { ApiClientError, getUsers } from "@/lib/api";
 import { hasAccessToken } from "@/lib/api/client";
 import type { User } from "@/types/api";
 import styles from "./users-page.module.css";
 
 export default function UsersPage() {
   const router = useRouter();
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
   useEffect(() => {
     const loggedIn = hasAccessToken();
-    setIsLoggedIn(loggedIn);
 
     if (!loggedIn) {
       router.replace("/login");
@@ -44,12 +41,6 @@ export default function UsersPage() {
     void load();
   }, [router]);
 
-  const onLogout = () => {
-    logout();
-    setIsLoggedIn(false);
-    router.push("/login");
-  };
-
   return (
     <div className={styles.page}>
       <main className={styles.main}>
@@ -57,18 +48,6 @@ export default function UsersPage() {
           <div>
             <p className={styles.kicker}>Employees</p>
             <h1>社員一覧</h1>
-          </div>
-          <div className={styles.links}>
-            <Link href="/">トップ</Link>
-            <Link href="/users/new">新規登録</Link>
-            <Link href="/seat-actions">座席操作</Link>
-            <Link href="/users/new">社員を登録する</Link>
-            {!isLoggedIn && <Link href="/login">ログイン</Link>}
-            {isLoggedIn && (
-              <button type="button" onClick={onLogout}>
-                ログアウト
-              </button>
-            )}
           </div>
         </header>
 

--- a/frontend/src/components/global-header-nav.module.css
+++ b/frontend/src/components/global-header-nav.module.css
@@ -1,0 +1,66 @@
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  backdrop-filter: blur(10px);
+  background: #ffffffd9;
+  border-bottom: 1px solid #d9e2ec;
+}
+
+.inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 10px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.brand {
+  color: #102a43;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.link,
+.logoutButton {
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334e68;
+  padding: 7px 12px;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.active {
+  border-color: #0f766e;
+  color: #0f766e;
+  background: #ccfbf1;
+}
+
+.logoutButton {
+  cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { logout } from "@/lib/api";
+import { hasAccessToken } from "@/lib/api/client";
+import styles from "./global-header-nav.module.css";
+
+type NavItem = {
+  href: string;
+  label: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/", label: "トップ" },
+  { href: "/users", label: "社員一覧" },
+  { href: "/users/new", label: "社員登録" },
+  { href: "/seat-actions", label: "座席操作" },
+  { href: "/current-seat-lookup", label: "現在位置照会" },
+  { href: "/login", label: "ログイン" },
+];
+
+export default function GlobalHeaderNav() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const loggedIn = hasAccessToken();
+
+  const onLogout = () => {
+    logout();
+    router.push("/login");
+  };
+
+  return (
+    <header className={styles.header}>
+      <div className={styles.inner}>
+        <Link href="/" className={styles.brand}>
+          OfficeNavi
+        </Link>
+        <nav className={styles.nav} aria-label="global">
+          {NAV_ITEMS.map((item) => {
+            const active = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={active ? "page" : undefined}
+                className={active ? `${styles.link} ${styles.active}` : styles.link}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+          {loggedIn && (
+            <button type="button" onClick={onLogout} className={styles.logoutButton}>
+              ログアウト
+            </button>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,5 +1,11 @@
 export { login, logout } from "@/lib/api/auth";
 export { ApiClientError, apiRequest } from "@/lib/api/client";
 export { getSeats } from "@/lib/api/seats";
-export { getCurrentSeat, leaveCurrentSeat, registerCurrentSeat } from "@/lib/api/user-seats";
+export {
+	getAllCurrentSeats,
+	getCurrentSeat,
+	getCurrentSeatByUserId,
+	leaveCurrentSeat,
+	registerCurrentSeat,
+} from "@/lib/api/user-seats";
 export { getUsers, registerUser } from "@/lib/api/users";

--- a/frontend/src/lib/api/user-seats.ts
+++ b/frontend/src/lib/api/user-seats.ts
@@ -22,3 +22,11 @@ export const leaveCurrentSeat = async () => {
 export const getCurrentSeat = async () => {
   return apiRequest<CurrentSeat>("/users/me/current-seat");
 };
+
+export const getCurrentSeatByUserId = async (userId: number) => {
+  return apiRequest<CurrentSeat>(`/users/${userId}/current-seat`);
+};
+
+export const getAllCurrentSeats = async () => {
+  return apiRequest<CurrentSeat[]>("/users/current-seats");
+};

--- a/src/main/java/com/example/officenavi/controller/UserSeatController.java
+++ b/src/main/java/com/example/officenavi/controller/UserSeatController.java
@@ -11,10 +11,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * 在席情報関連APIを提供するコントローラーです。
@@ -71,6 +74,29 @@ public class UserSeatController {
     public ResponseEntity<UserCurrentSeatResponse> getCurrentSeat(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
         UserCurrentSeatResponse response = userSeatService.getCurrentSeat(authenticatedUser.userId());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 指定ユーザーの現在位置を取得します。
+     *
+     * @param userId ユーザーID
+     * @return 200 OK（現在位置情報）
+     */
+    @GetMapping("/users/{userId}/current-seat")
+    public ResponseEntity<UserCurrentSeatResponse> getCurrentSeatByUserId(@PathVariable Integer userId) {
+        UserCurrentSeatResponse response = userSeatService.getCurrentSeat(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 現在在席中のユーザー一覧を取得します。
+     *
+     * @return 200 OK（現在位置情報一覧）
+     */
+    @GetMapping("/users/current-seats")
+    public ResponseEntity<List<UserCurrentSeatResponse>> getAllCurrentSeats() {
+        List<UserCurrentSeatResponse> response = userSeatService.getAllCurrentSeats();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
+++ b/src/main/java/com/example/officenavi/repository/UserSeatRepository.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,21 +18,20 @@ import java.util.Optional;
 @Repository
 public class UserSeatRepository {
 
-    private static final RowMapper<UserCurrentSeatEntity> USER_CURRENT_SEAT_ROW_MAPPER = (rs, rowNum) -> new UserCurrentSeatEntity(
-            rs.getInt("user_id"),
-            rs.getString("user_name"),
-            rs.getInt("seat_id"),
-            rs.getString("seat_name"),
-            rs.getString("seat_location"),
-            rs.getTimestamp("since").toLocalDateTime()
-    );
+    private static final RowMapper<UserCurrentSeatEntity> USER_CURRENT_SEAT_ROW_MAPPER = (rs,
+            rowNum) -> new UserCurrentSeatEntity(
+                    rs.getInt("user_id"),
+                    rs.getString("user_name"),
+                    rs.getInt("seat_id"),
+                    rs.getString("seat_name"),
+                    rs.getString("seat_location"),
+                    rs.getTimestamp("since").toLocalDateTime());
 
     private static final RowMapper<UserSeatEntity> USER_SEAT_ROW_MAPPER = (rs, rowNum) -> new UserSeatEntity(
             rs.getInt("id"),
             rs.getInt("user_id"),
             rs.getInt("seat_id"),
-            rs.getTimestamp("start_time").toLocalDateTime()
-    );
+            rs.getTimestamp("start_time").toLocalDateTime());
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -180,5 +180,28 @@ public class UserSeatRepository {
                 """;
         SqlParameterSource param = new MapSqlParameterSource().addValue("userId", userId);
         return jdbcTemplate.query(sql, param, USER_CURRENT_SEAT_ROW_MAPPER).stream().findFirst();
+    }
+
+    /**
+     * 現在在席中のユーザーを全件取得します。
+     *
+     * @return 現在位置情報一覧
+     */
+    public List<UserCurrentSeatEntity> findAllCurrentSeats() {
+        String sql = """
+                SELECT
+                    u.id AS user_id,
+                    u.name AS user_name,
+                    s.id AS seat_id,
+                    s.name AS seat_name,
+                    s.location AS seat_location,
+                    us.start_time AS since
+                FROM user_seats us
+                INNER JOIN users u ON u.id = us.user_id
+                INNER JOIN seats s ON s.id = us.seat_id
+                WHERE us.end_time IS NULL
+                ORDER BY u.id ASC
+                """;
+        return jdbcTemplate.query(sql, USER_CURRENT_SEAT_ROW_MAPPER);
     }
 }

--- a/src/main/java/com/example/officenavi/service/UserSeatService.java
+++ b/src/main/java/com/example/officenavi/service/UserSeatService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 在席情報の業務ロジックを扱うサービスです。
@@ -99,6 +100,21 @@ public class UserSeatService {
                         "CURRENT_SEAT_NOT_FOUND",
                         "対象ユーザーの現在位置が登録されていません"));
 
+        return toResponse(entity);
+    }
+
+    /**
+     * 現在在席中のユーザー一覧を取得します。
+     *
+     * @return 現在位置取得レスポンス一覧
+     */
+    public List<UserCurrentSeatResponse> getAllCurrentSeats() {
+        return userSeatRepository.findAllCurrentSeats().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private UserCurrentSeatResponse toResponse(UserCurrentSeatEntity entity) {
         return new UserCurrentSeatResponse(
                 entity.getUserId(),
                 entity.getUserName(),

--- a/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/UserSeatControllerTest.java
@@ -138,6 +138,57 @@ class UserSeatControllerTest {
         }
 
         @Test
+        void getCurrentSeatByUserId_shouldReturn200() throws Exception {
+                UserCurrentSeatResponse response = new UserCurrentSeatResponse(
+                                5,
+                                "佐藤花子",
+                                new UserCurrentSeatResponse.SeatInfo(20, "B-20", "4F West"),
+                                LocalDateTime.of(2026, 3, 24, 9, 0, 0));
+                when(userSeatService.getCurrentSeat(5)).thenReturn(response);
+
+                mockMvc.perform(get("/api/users/5/current-seat")
+                                .with(loginAs(1)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.userId").value(5))
+                                .andExpect(jsonPath("$.userName").value("佐藤花子"))
+                                .andExpect(jsonPath("$.seat.id").value(20));
+        }
+
+        @Test
+        void getCurrentSeatByUserId_whenNotFound_shouldReturn404() throws Exception {
+                when(userSeatService.getCurrentSeat(404))
+                                .thenThrow(new ResourceNotFoundException("CURRENT_SEAT_NOT_FOUND",
+                                                "対象ユーザーの現在位置が登録されていません"));
+
+                mockMvc.perform(get("/api/users/404/current-seat")
+                                .with(loginAs(1)))
+                                .andExpect(status().isNotFound())
+                                .andExpect(jsonPath("$.code").value("CURRENT_SEAT_NOT_FOUND"));
+        }
+
+        @Test
+        void getAllCurrentSeats_shouldReturn200() throws Exception {
+                when(userSeatService.getAllCurrentSeats()).thenReturn(List.of(
+                                new UserCurrentSeatResponse(
+                                                1,
+                                                "山田太郎",
+                                                new UserCurrentSeatResponse.SeatInfo(10, "A-01", "3F East"),
+                                                LocalDateTime.of(2026, 3, 24, 9, 0, 0)),
+                                new UserCurrentSeatResponse(
+                                                2,
+                                                "佐藤花子",
+                                                new UserCurrentSeatResponse.SeatInfo(20, "B-10", "4F West"),
+                                                LocalDateTime.of(2026, 3, 24, 9, 15, 0))));
+
+                mockMvc.perform(get("/api/users/current-seats")
+                                .with(loginAs(1)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].userId").value(1))
+                                .andExpect(jsonPath("$[0].seat.id").value(10))
+                                .andExpect(jsonPath("$[1].userId").value(2));
+        }
+
+        @Test
         void registerCurrentSeat_whenUserNotFound_shouldReturn404() throws Exception {
                 when(userSeatService.registerCurrentSeat(anyInt(), anyInt()))
                                 .thenThrow(new ResourceNotFoundException("USER_NOT_FOUND", "指定されたuserIdは存在しません"));


### PR DESCRIPTION
# 概要
- 画面ごとに重複していた導線を共通ヘッダーへ集約しました。
- 全画面から主要画面へ遷移できるよう統一しました。

# 関連Issue
- Issue: #51 

# 変更内容
- Backend:
  - 変更なし
- Frontend:
  - 共通ヘッダーコンポーネントを追加
  - レイアウトへ組み込み
  - 各画面に散在していた旧導線（個別リンク群）を削除
  - ログイン状態に応じた導線表示を共通ヘッダー側へ集約
- Infra/Config:
  - 変更なし

# 動作確認内容
1. 手順:
   - トップ、社員一覧、社員登録、座席操作、現在位置照会、ログイン画面を順に開く
   - 共通ヘッダーから各画面へ遷移する
2. 期待結果:
   - どの画面からでも同一導線で遷移できる
   - 重複導線がページ内に残っていない

# リスク・影響範囲
- 影響範囲:
  - 全画面のナビゲーション表示
- 懸念点:
  - 画面幅が狭い端末での折り返し表示