### PR TITLE
[BUG] 未ログイン時の遷移ガード追加とヘッダーの認証状態表示修正

### DIFF
--- a/frontend/src/app/current-seat-lookup/page.tsx
+++ b/frontend/src/app/current-seat-lookup/page.tsx
@@ -2,7 +2,9 @@
 
 import { FormEvent, useState } from "react";
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { ApiClientError, getAllCurrentSeats, getCurrentSeatByUserId } from "@/lib/api";
+import { hasAccessToken } from "@/lib/api/client";
 import type { CurrentSeat } from "@/types/api";
 import styles from "./current-seat-lookup-page.module.css";
 
@@ -11,6 +13,7 @@ const isPositiveInteger = (value: string) => {
 };
 
 export default function CurrentSeatLookupPage() {
+  const router = useRouter();
   const [userIdInput, setUserIdInput] = useState("");
   const [submittedUserId, setSubmittedUserId] = useState<number | null>(null);
   const [results, setResults] = useState<CurrentSeat[]>([]);
@@ -36,6 +39,11 @@ export default function CurrentSeatLookupPage() {
       }
     } catch (err) {
       setResults([]);
+      if (err instanceof ApiClientError && err.status === 401) {
+        router.replace("/login");
+        return;
+      }
+
       if (err instanceof ApiClientError && err.status >= 500) {
         setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
       } else if (err instanceof ApiClientError) {
@@ -58,6 +66,11 @@ export default function CurrentSeatLookupPage() {
       const data = await getCurrentSeatByUserId(userId);
       setResults([data]);
     } catch (err) {
+      if (err instanceof ApiClientError && err.status === 401) {
+        router.replace("/login");
+        return;
+      }
+
       if (err instanceof ApiClientError && err.status === 404) {
         setEmptyMessage(`userId=${userId} の現在位置は登録されていません。`);
       } else if (err instanceof ApiClientError && err.status >= 500) {
@@ -73,6 +86,11 @@ export default function CurrentSeatLookupPage() {
   };
 
   useEffect(() => {
+    if (!hasAccessToken()) {
+      router.replace("/login");
+      return;
+    }
+
     const loadInitial = async () => {
       clearMessages();
       setSubmittedUserId(null);
@@ -86,6 +104,11 @@ export default function CurrentSeatLookupPage() {
         }
       } catch (err) {
         setResults([]);
+        if (err instanceof ApiClientError && err.status === 401) {
+          router.replace("/login");
+          return;
+        }
+
         if (err instanceof ApiClientError && err.status >= 500) {
           setErrorMessage("サーバーエラーが発生しました。時間をおいて再試行してください。");
         } else if (err instanceof ApiClientError) {
@@ -99,7 +122,7 @@ export default function CurrentSeatLookupPage() {
     };
 
     void loadInitial();
-  }, []);
+  }, [router]);
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/src/app/seat-actions/page.tsx
+++ b/frontend/src/app/seat-actions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   ApiClientError,
   getCurrentSeat,
@@ -8,6 +9,7 @@ import {
   leaveCurrentSeat,
   registerCurrentSeat,
 } from "@/lib/api";
+import { hasAccessToken } from "@/lib/api/client";
 import type { CurrentSeat, Seat } from "@/types/api";
 import styles from "./seat-actions-page.module.css";
 
@@ -21,6 +23,7 @@ const getSeatConflictMessage = (error: ApiClientError) => {
 };
 
 export default function SeatActionsPage() {
+  const router = useRouter();
   const [seats, setSeats] = useState<Seat[]>([]);
   const [selectedSeatId, setSelectedSeatId] = useState("");
   const [currentSeat, setCurrentSeat] = useState<CurrentSeat | null>(null);
@@ -35,6 +38,11 @@ export default function SeatActionsPage() {
   const [notice, setNotice] = useState("");
 
   useEffect(() => {
+    if (!hasAccessToken()) {
+      router.replace("/login");
+      return;
+    }
+
     const loadData = async () => {
       try {
         setLoadingInitial(true);
@@ -54,6 +62,11 @@ export default function SeatActionsPage() {
         setSeats(seatsData);
         setCurrentSeat(currentSeatData);
       } catch (err) {
+        if (err instanceof ApiClientError && err.status === 401) {
+          router.replace("/login");
+          return;
+        }
+
         if (err instanceof ApiClientError) {
           setError(err.message);
         } else {
@@ -66,7 +79,7 @@ export default function SeatActionsPage() {
     };
 
     void loadData();
-  }, []);
+  }, [router]);
 
   const canSubmitSeat = useMemo(() => {
     return !!selectedSeatId && !submittingSeat && !submittingLeave;
@@ -102,6 +115,11 @@ export default function SeatActionsPage() {
         return;
       }
 
+      if (err instanceof ApiClientError && err.status === 401) {
+        router.replace("/login");
+        return;
+      }
+
       if (err instanceof ApiClientError) {
         setError(err.message);
       } else {
@@ -124,6 +142,11 @@ export default function SeatActionsPage() {
       setCurrentSeat(null);
       setNotice("退席登録が完了しました");
     } catch (err) {
+      if (err instanceof ApiClientError && err.status === 401) {
+        router.replace("/login");
+        return;
+      }
+
       if (err instanceof ApiClientError) {
         setError(err.message);
       } else {

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -17,13 +17,20 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/users/new", label: "社員登録" },
   { href: "/seat-actions", label: "座席操作" },
   { href: "/current-seat-lookup", label: "現在位置照会" },
-  { href: "/login", label: "ログイン" },
 ];
 
 export default function GlobalHeaderNav() {
   const pathname = usePathname();
   const router = useRouter();
   const loggedIn = hasAccessToken();
+
+  if (pathname === "/login") {
+    return null;
+  }
+
+  const onLogin = () => {
+    router.push("/login");
+  };
 
   const onLogout = () => {
     logout();
@@ -50,11 +57,14 @@ export default function GlobalHeaderNav() {
               </Link>
             );
           })}
-          {loggedIn && (
-            <button type="button" onClick={onLogout} className={styles.logoutButton}>
-              ログアウト
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={loggedIn ? onLogout : onLogin}
+            className={styles.logoutButton}
+            aria-label={loggedIn ? "ログアウト" : "ログイン"}
+          >
+            {loggedIn ? "ログアウト" : "ログイン"}
+          </button>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
# 概要
- 未ログイン時に「座席操作」「現在位置照会」でAPIエラーメッセージを表示するのではなく、ログイン画面へ遷移させるための認証ガードを追加しました。
- ヘッダーの認証状態表示を見直し、ログイン時は「ログアウト」、ログアウト時は「ログイン」を表示するように統一しました。
- ログイン画面ではヘッダーを非表示にしました。

# 関連Issue
- Issue: #

# 変更内容
- Backend:
  - なし
- Frontend:
  - seat-actions画面に認証ガードを追加（未ログイン時は /login へ遷移）
  - current-seat-lookup画面に認証ガードを追加（未ログイン時は /login へ遷移）
  - 上記2画面でAPI呼び出し時に401を受けた場合も /login へ遷移
  - ヘッダーのログイン/ログアウトアクションを1ボタンで認証状態に応じて切替
  - /login ではヘッダー非表示

# 動作確認内容
1. 手順:
   1. 未ログイン状態で「座席操作」へアクセス
   2. 未ログイン状態で「現在位置照会」へアクセス
   3. ログイン状態でヘッダー表示を確認
   4. ログアウト状態でヘッダー表示を確認
   5. /login 画面を表示してヘッダー表示を確認
   6. フロントで lint を実行（npm run lint）
2. 期待結果:
   - 1,2: いずれも /login へ遷移し、認証エラーメッセージは表示されない
   - 3: ヘッダーは「ログアウト」表示
   - 4: ヘッダーは「ログイン」表示
   - 5: ヘッダーが表示されない
   - 6: lint エラーなし

# リスク・影響範囲
- 影響範囲:
  - 認証が必要なフロント画面の遷移制御
  - グローバルヘッダーの表示
- 懸念点:
  - localStorageベース判定のため、トークン有効期限切れ時はAPI 401を契機に遷移する挙動になる