### PR TITLE
[FEATURE] 社員登録を管理者限定表示に変更し、roleCodeをログインレスポンスで連携

### DIFF
--- a/frontend/src/app/users/new/page.tsx
+++ b/frontend/src/app/users/new/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ApiClientError, registerUser } from "@/lib/api";
-import { hasAccessToken } from "@/lib/api/client";
+import { hasAccessToken, isAdminUser } from "@/lib/api/client";
 import type { UserRegisterRequest } from "@/types/api";
 import styles from "./users-new-page.module.css";
 
@@ -81,6 +81,11 @@ export default function NewUserPage() {
 
     if (!loggedIn) {
       router.replace("/login");
+      return;
+    }
+
+    if (!isAdminUser()) {
+      router.replace("/users");
     }
   }, [router]);
 
@@ -131,6 +136,11 @@ export default function NewUserPage() {
       router.push("/users");
     } catch (err) {
       if (err instanceof ApiClientError) {
+        if (err.status === 403) {
+          router.replace("/users");
+          return;
+        }
+
         const serverFieldErrors = toServerFieldErrors(err);
         setFieldErrors(serverFieldErrors);
 

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { logout } from "@/lib/api";
-import { hasAccessToken } from "@/lib/api/client";
+import { hasAccessToken, isAdminUser } from "@/lib/api/client";
 import styles from "./global-header-nav.module.css";
 
 type NavItem = {
@@ -14,7 +14,6 @@ type NavItem = {
 const NAV_ITEMS: NavItem[] = [
   { href: "/", label: "トップ" },
   { href: "/users", label: "社員一覧" },
-  { href: "/users/new", label: "社員登録" },
   { href: "/seat-actions", label: "座席操作" },
   { href: "/current-seat-lookup", label: "現在位置照会" },
 ];
@@ -23,6 +22,7 @@ export default function GlobalHeaderNav() {
   const pathname = usePathname();
   const router = useRouter();
   const loggedIn = hasAccessToken();
+  const isAdmin = loggedIn && isAdminUser();
 
   if (pathname === "/login") {
     return null;
@@ -57,6 +57,15 @@ export default function GlobalHeaderNav() {
               </Link>
             );
           })}
+          {isAdmin && (
+            <Link
+              href="/users/new"
+              aria-current={pathname === "/users/new" ? "page" : undefined}
+              className={pathname === "/users/new" ? `${styles.link} ${styles.active}` : styles.link}
+            >
+              社員登録
+            </Link>
+          )}
           <button
             type="button"
             onClick={loggedIn ? onLogout : onLogin}

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiRequest, setAccessToken } from "@/lib/api/client";
+import { apiRequest, setAccessToken, setRoleCode } from "@/lib/api/client";
 import type { LoginRequest, LoginResponse } from "@/types/api";
 
 export const login = async (payload: LoginRequest) => {
@@ -8,9 +8,11 @@ export const login = async (payload: LoginRequest) => {
   });
 
   setAccessToken(response.accessToken);
+  setRoleCode(response.roleCode);
   return response;
 };
 
 export const logout = () => {
   setAccessToken(null);
+  setRoleCode(null);
 };

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -5,6 +5,8 @@ const DEFAULT_HEADERS = {
 } as const;
 
 const ACCESS_TOKEN_STORAGE_KEY = "officenavi_access_token";
+const ROLE_CODE_STORAGE_KEY = "officenavi_role_code";
+const ROLE_ADMIN = 0;
 
 export class ApiClientError extends Error {
   status: number;
@@ -31,6 +33,37 @@ const getAccessToken = () => {
 
 export const hasAccessToken = () => {
   return !!getAccessToken();
+};
+
+const getRoleCode = (): number | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const roleCode = window.localStorage.getItem(ROLE_CODE_STORAGE_KEY);
+  if (roleCode === null) {
+    return null;
+  }
+
+  const parsed = Number(roleCode);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const setRoleCode = (roleCode: number | null) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (roleCode === null) {
+    window.localStorage.removeItem(ROLE_CODE_STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(ROLE_CODE_STORAGE_KEY, String(roleCode));
+};
+
+export const isAdminUser = () => {
+  return getRoleCode() === ROLE_ADMIN;
 };
 
 export const setAccessToken = (token: string | null) => {
@@ -103,6 +136,7 @@ export const apiRequest = async <T>(path: string, init?: RequestInit): Promise<T
   if (!response.ok) {
     if (response.status === 401) {
       setAccessToken(null);
+      setRoleCode(null);
     }
     throw new ApiClientError(response.status, toApiErrorResponse(body as ApiErrorResponse | null));
   }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -40,13 +40,22 @@ const getRoleCode = (): number | null => {
     return null;
   }
 
-  const roleCode = window.localStorage.getItem(ROLE_CODE_STORAGE_KEY);
-  if (roleCode === null) {
+  const roleCodeRaw = window.localStorage.getItem(ROLE_CODE_STORAGE_KEY);
+  if (roleCodeRaw === null) {
     return null;
   }
 
-  const parsed = Number(roleCode);
-  return Number.isNaN(parsed) ? null : parsed;
+  const roleCode = roleCodeRaw.trim();
+  if (!/^\d+$/.test(roleCode)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(roleCode, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    return null;
+  }
+
+  return parsed;
 };
 
 export const setRoleCode = (roleCode: number | null) => {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -13,6 +13,7 @@ export type LoginResponse = {
   accessToken: string;
   tokenType: string;
   expiresIn: number;
+  roleCode: number;
 };
 
 export type UserRegisterRequest = {

--- a/src/main/java/com/example/officenavi/domain/auth/LoginResponse.java
+++ b/src/main/java/com/example/officenavi/domain/auth/LoginResponse.java
@@ -8,11 +8,13 @@ public class LoginResponse {
     private final String accessToken;
     private final String tokenType;
     private final long expiresIn;
+    private final Integer roleCode;
 
-    public LoginResponse(String accessToken, String tokenType, long expiresIn) {
+    public LoginResponse(String accessToken, String tokenType, long expiresIn, Integer roleCode) {
         this.accessToken = accessToken;
         this.tokenType = tokenType;
         this.expiresIn = expiresIn;
+        this.roleCode = roleCode;
     }
 
     public String getAccessToken() {
@@ -25,5 +27,9 @@ public class LoginResponse {
 
     public long getExpiresIn() {
         return expiresIn;
+    }
+
+    public Integer getRoleCode() {
+        return roleCode;
     }
 }

--- a/src/main/java/com/example/officenavi/service/AuthService.java
+++ b/src/main/java/com/example/officenavi/service/AuthService.java
@@ -37,6 +37,6 @@ public class AuthService {
 
         String accessToken = jwtTokenProvider.generateToken(user.getId(), user.getEmail(), user.getRoleCode());
 
-        return new LoginResponse(accessToken, "Bearer", jwtTokenProvider.getExpirationSeconds());
+        return new LoginResponse(accessToken, "Bearer", jwtTokenProvider.getExpirationSeconds(), user.getRoleCode());
     }
 }


### PR DESCRIPTION
# 概要
- 社員登録機能は管理者（ROLE_ADMIN）のみ利用可能なため、フロント側でも管理者のみ導線・画面表示されるように変更しました。
- JWTデコードでのロール判定をやめ、バックエンドのログインレスポンスに roleCode を含めてフロントに連携する方式へ変更しました。

# 関連Issue
- Issue: #56 

# 変更内容
- Backend:
  - LoginResponse に roleCode を追加
  - AuthService のログイン成功レスポンスで roleCode を返却
- Frontend:
  - LoginResponse 型に roleCode を追加
  - ログイン時に roleCode を保存、ログアウト時/401時に roleCode を削除
  - ヘッダーの「社員登録」導線を管理者のみ表示
  - 社員登録画面で未ログイン時は /login、非管理者は /users にリダイレクト
  - 社員登録APIで 403 を受けた場合も /users にリダイレクト

# 動作確認内容
1. 手順:
   1. ROLE_ADMIN でログイン
   2. ヘッダーに「社員登録」が表示されることを確認
   3. ROLE_USER でログイン
   4. ヘッダーに「社員登録」が表示されないことを確認
   5. ROLE_USER で /users/new に直接アクセス
   6. フロント lint 実行（npm run lint）
   7. バックエンド compile 実行（./mvnw -q -DskipTests compile）
2. 期待結果:
   - 管理者のみ社員登録導線が表示される
   - 非管理者は社員登録画面を利用できない（/users へ遷移）
   - lint/compile が成功する

# リスク・影響範囲
- 影響範囲:
  - ログインレスポンス仕様（roleCode追加）
  - 認証状態保持ロジック（accessToken + roleCode）
  - ヘッダーナビゲーション表示
  - 社員登録画面のアクセス制御
- 懸念点:
  - roleCode の保持が消えた状態（localStorage破損等）で一時的に非管理者扱いになる可能性
  - 今後ロール種別が増えた場合はフロント判定ロジックの拡張が必要