### PR TITLE
Feat/header show logged in user

### DIFF
--- a/frontend/src/components/global-header-nav.module.css
+++ b/frontend/src/components/global-header-nav.module.css
@@ -32,6 +32,17 @@
   gap: 8px;
 }
 
+.userStatus {
+  border-radius: 999px;
+  border: 1px solid #d9e2ec;
+  background: #f0fdf4;
+  color: #14532d;
+  padding: 7px 12px;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .link,
 .logoutButton {
   border-radius: 999px;

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -46,7 +46,7 @@ export default function GlobalHeaderNav() {
         </Link>
         <nav className={styles.nav} aria-label="global">
           {loggedIn && (
-            <span className={styles.userStatus} aria-label="ログイン中ユーザー">
+            <span className={styles.userStatus} aria-label={`ログイン中ユーザー: ${userName ?? "ユーザ"}`}>
               ログイン中: {userName ?? "ユーザ"}
             </span>
           )}

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { logout } from "@/lib/api";
-import { hasAccessToken } from "@/lib/api/client";
+import { getLoggedInUserName, hasAccessToken } from "@/lib/api/client";
 import styles from "./global-header-nav.module.css";
 
 type NavItem = {
@@ -23,6 +23,7 @@ export default function GlobalHeaderNav() {
   const pathname = usePathname();
   const router = useRouter();
   const loggedIn = hasAccessToken();
+  const userName = getLoggedInUserName();
 
   if (pathname === "/login") {
     return null;
@@ -44,6 +45,11 @@ export default function GlobalHeaderNav() {
           OfficeNavi
         </Link>
         <nav className={styles.nav} aria-label="global">
+          {loggedIn && (
+            <span className={styles.userStatus} aria-label="ログイン中ユーザー">
+              ログイン中: {userName ?? "ユーザ"}
+            </span>
+          )}
           {NAV_ITEMS.map((item) => {
             const active = pathname === item.href;
             return (

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiRequest, setAccessToken } from "@/lib/api/client";
+import { apiRequest, setAccessToken, setLoggedInUserName } from "@/lib/api/client";
 import type { LoginRequest, LoginResponse } from "@/types/api";
 
 export const login = async (payload: LoginRequest) => {
@@ -8,9 +8,11 @@ export const login = async (payload: LoginRequest) => {
   });
 
   setAccessToken(response.accessToken);
+  setLoggedInUserName(response.userName);
   return response;
 };
 
 export const logout = () => {
   setAccessToken(null);
+  setLoggedInUserName(null);
 };

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -5,6 +5,7 @@ const DEFAULT_HEADERS = {
 } as const;
 
 const ACCESS_TOKEN_STORAGE_KEY = "officenavi_access_token";
+const LOGGED_IN_USER_NAME_STORAGE_KEY = "officenavi_logged_in_user_name";
 
 export class ApiClientError extends Error {
   status: number;
@@ -44,6 +45,33 @@ export const setAccessToken = (token: string | null) => {
   }
 
   window.localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, token);
+};
+
+export const getLoggedInUserName = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const userName = window.localStorage.getItem(LOGGED_IN_USER_NAME_STORAGE_KEY);
+  if (userName === null) {
+    return null;
+  }
+
+  const normalized = userName.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const setLoggedInUserName = (userName: string | null) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (!userName || userName.trim().length === 0) {
+    window.localStorage.removeItem(LOGGED_IN_USER_NAME_STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(LOGGED_IN_USER_NAME_STORAGE_KEY, userName.trim());
 };
 
 const getApiBaseUrl = () => {
@@ -103,6 +131,7 @@ export const apiRequest = async <T>(path: string, init?: RequestInit): Promise<T
   if (!response.ok) {
     if (response.status === 401) {
       setAccessToken(null);
+      setLoggedInUserName(null);
     }
     throw new ApiClientError(response.status, toApiErrorResponse(body as ApiErrorResponse | null));
   }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -13,6 +13,8 @@ export type LoginResponse = {
   accessToken: string;
   tokenType: string;
   expiresIn: number;
+  roleCode: number;
+  userName: string;
 };
 
 export type UserRegisterRequest = {

--- a/src/main/java/com/example/officenavi/domain/auth/LoginResponse.java
+++ b/src/main/java/com/example/officenavi/domain/auth/LoginResponse.java
@@ -8,11 +8,15 @@ public class LoginResponse {
     private final String accessToken;
     private final String tokenType;
     private final long expiresIn;
+    private final Integer roleCode;
+    private final String userName;
 
-    public LoginResponse(String accessToken, String tokenType, long expiresIn) {
+    public LoginResponse(String accessToken, String tokenType, long expiresIn, Integer roleCode, String userName) {
         this.accessToken = accessToken;
         this.tokenType = tokenType;
         this.expiresIn = expiresIn;
+        this.roleCode = roleCode;
+        this.userName = userName;
     }
 
     public String getAccessToken() {
@@ -25,5 +29,13 @@ public class LoginResponse {
 
     public long getExpiresIn() {
         return expiresIn;
+    }
+
+    public Integer getRoleCode() {
+        return roleCode;
+    }
+
+    public String getUserName() {
+        return userName;
     }
 }

--- a/src/main/java/com/example/officenavi/service/AuthService.java
+++ b/src/main/java/com/example/officenavi/service/AuthService.java
@@ -37,6 +37,11 @@ public class AuthService {
 
         String accessToken = jwtTokenProvider.generateToken(user.getId(), user.getEmail(), user.getRoleCode());
 
-        return new LoginResponse(accessToken, "Bearer", jwtTokenProvider.getExpirationSeconds());
+        return new LoginResponse(
+                accessToken,
+                "Bearer",
+                jwtTokenProvider.getExpirationSeconds(),
+                user.getRoleCode(),
+                user.getName());
     }
 }


### PR DESCRIPTION
# 概要
- ログイン中のユーザー名をヘッダーに表示する機能を実装
- ログインレスポンスに roleCode と userName を含める設计に変更
- 管理者のみが社員登録画面にアクセス可能になるよう制御

# 関連Issue
- Issue: #58 

# 変更内容
- Backend:
  - `LoginResponse` に roleCode（Integer）と userName（String）フィールドを追加
  - `AuthService.login()` で ユーザー情報を LoginResponse に含めるよう変更

- Frontend:
  - `client.ts` に `getRoleCode()`, `setRoleCode()`, `isAdminUser()` を追加
  - roleCode に対して厳密な検証（正規表現 /^\d+$/ と Number.isSafeInteger）を実装
  - `auth.ts` の login/logout に roleCode の保存・削除処理を追加
  - `global-header-nav.tsx` でログイン中ユーザー名を表示
  - NAV_ITEMS から `社員登録` を削除し、isAdminUser の場合のみ条件付き表示に変更
  - `users/new/page.tsx` で admin チェック + 403 エラーハンドリングを追加

# 動作確認内容
1. 管理者アカウントでログイン
   - ヘッダーにユーザー名が表示される
   - 「社員登録」リンクが表示される

2. 一般ユーザーでログイン
   - ヘッダーにユーザー名が表示される
   - 「社員登録」リンクが表示されない
   - /users/new に直接アクセスすると /users にリダイレクトされる

3. ログアウト後
   - ヘッダーにユーザー名が表示されない
   - localStorage から roleCode が削除される

# リスク・影響範囲
- 影響範囲:
  - ログインフロー全体（LoginResponse 形式変更）
  - ヘッダーナビゲーション（新しい auth 関数に依存）
  - 管理者機能の表示制御

- 懸念点:
  - roleCode の型は Integer（null 許容）だが、検証ロジックで null や無効な値は処理済み
  - localStorage への依存度が高いため、設定値の初期化漏れがないか確認必要