### PR TITLE
fix: ログアウト確認ダイアログの状態管理を改善

### DIFF
--- a/frontend/src/components/global-header-nav.module.css
+++ b/frontend/src/components/global-header-nav.module.css
@@ -65,6 +65,73 @@
   cursor: pointer;
 }
 
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.45);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  z-index: 50;
+}
+
+.modal {
+  width: min(420px, 100%);
+  border-radius: 14px;
+  border: 1px solid #d9e2ec;
+  background: #fff;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.modalTitle {
+  margin: 0;
+  color: #102a43;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.modalDescription {
+  margin: 0;
+  color: #486581;
+  font-size: 14px;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancelButton,
+.confirmButton {
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  padding: 9px 14px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.cancelButton {
+  background: #fff;
+  color: #334e68;
+}
+
+.confirmButton {
+  border-color: #0f766e;
+  background: #0f766e;
+  color: #fff;
+}
+
+.cancelButton:disabled,
+.confirmButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 @media (max-width: 900px) {
   .inner {
     align-items: flex-start;

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { logout } from "@/lib/api";
@@ -9,6 +10,12 @@ import styles from "./global-header-nav.module.css";
 type NavItem = {
   href: string;
   label: string;
+};
+
+type AuthState = {
+  loggedIn: boolean;
+  isAdmin: boolean;
+  userName: string | null;
 };
 
 const NAV_ITEMS: NavItem[] = [
@@ -21,22 +28,76 @@ const NAV_ITEMS: NavItem[] = [
 export default function GlobalHeaderNav() {
   const pathname = usePathname();
   const router = useRouter();
-  const loggedIn = hasAccessToken();
-  const isAdmin = loggedIn && isAdminUser();
-  const userName = getLoggedInUserName();
+  const [authState, setAuthState] = useState<AuthState>({
+    loggedIn: false,
+    isAdmin: false,
+    userName: null,
+  });
+  const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const syncAuthStateFromStorage = () => {
+    const loggedIn = hasAccessToken();
+    setAuthState({
+      loggedIn,
+      isAdmin: loggedIn && isAdminUser(),
+      userName: getLoggedInUserName(),
+    });
+  };
+
+  useEffect(() => {
+    syncAuthStateFromStorage();
+    setIsSubmitting(false);
+    setShowLogoutConfirm(false);
+  }, [pathname]);
+
+  const onLogin = useCallback(() => {
+    router.push("/login");
+  }, [router]);
+
+  const onLogoutClick = useCallback(() => {
+    setShowLogoutConfirm(true);
+  }, []);
+
+  const onCancelLogout = useCallback(() => {
+    if (isSubmitting) return;
+    setShowLogoutConfirm(false);
+  }, [isSubmitting]);
+
+  const onConfirmLogout = useCallback(() => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      logout();
+      setAuthState({ loggedIn: false, isAdmin: false, userName: null });
+      setShowLogoutConfirm(false);
+      router.push("/login");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [isSubmitting, router]);
+
+  useEffect(() => {
+    if (!showLogoutConfirm) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancelLogout();
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        onConfirmLogout();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [showLogoutConfirm, onCancelLogout, onConfirmLogout]);
 
   if (pathname === "/login") {
     return null;
   }
-
-  const onLogin = () => {
-    router.push("/login");
-  };
-
-  const onLogout = () => {
-    logout();
-    router.push("/login");
-  };
 
   return (
     <header className={styles.header}>
@@ -45,9 +106,9 @@ export default function GlobalHeaderNav() {
           OfficeNavi
         </Link>
         <nav className={styles.nav} aria-label="global">
-          {loggedIn && (
-            <span className={styles.userStatus} aria-label={`ログイン中ユーザー: ${userName ?? "ユーザ"}`}>
-              ログイン中: {userName ?? "ユーザ"}
+          {authState.loggedIn && (
+            <span className={styles.userStatus} aria-label={`ログイン中ユーザー: ${authState.userName ?? "ユーザ"}`}>
+              ログイン中: {authState.userName ?? "ユーザ"}
             </span>
           )}
           {NAV_ITEMS.map((item) => {
@@ -63,7 +124,7 @@ export default function GlobalHeaderNav() {
               </Link>
             );
           })}
-          {isAdmin && (
+          {authState.isAdmin && (
             <Link
               href="/users/new"
               aria-current={pathname === "/users/new" ? "page" : undefined}
@@ -74,14 +135,37 @@ export default function GlobalHeaderNav() {
           )}
           <button
             type="button"
-            onClick={loggedIn ? onLogout : onLogin}
+            onClick={authState.loggedIn ? onLogoutClick : onLogin}
             className={styles.logoutButton}
-            aria-label={loggedIn ? "ログアウト" : "ログイン"}
+            aria-label={authState.loggedIn ? "ログアウト" : "ログイン"}
           >
-            {loggedIn ? "ログアウト" : "ログイン"}
+            {authState.loggedIn ? "ログアウト" : "ログイン"}
           </button>
         </nav>
       </div>
+
+      {showLogoutConfirm && (
+        <div className={styles.modalOverlay} role="presentation" onClick={onCancelLogout}>
+          <div
+            className={styles.modal}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="logout-confirm-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h2 id="logout-confirm-title" className={styles.modalTitle}>ログアウトしますか？</h2>
+            <p className={styles.modalDescription}>未保存の入力内容は失われる可能性があります。</p>
+            <div className={styles.modalActions}>
+              <button type="button" className={styles.cancelButton} onClick={onCancelLogout} disabled={isSubmitting}>
+                いいえ
+              </button>
+              <button type="button" className={styles.confirmButton} onClick={onConfirmLogout} disabled={isSubmitting}>
+                {isSubmitting ? "処理中..." : "はい"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { logout } from "@/lib/api";
@@ -16,6 +16,17 @@ type AuthState = {
   loggedIn: boolean;
   isAdmin: boolean;
   userName: string | null;
+};
+
+const getDisplayUserName = (userName: string | null) => userName ?? "ユーザ";
+
+const getFocusableButtons = (
+  cancelButton: HTMLButtonElement | null,
+  confirmButton: HTMLButtonElement | null
+) => {
+  return [cancelButton, confirmButton].filter(
+    (element): element is HTMLButtonElement => element !== null && !element.disabled
+  );
 };
 
 const SERVER_AUTH_SNAPSHOT: AuthState = {
@@ -64,7 +75,14 @@ export default function GlobalHeaderNav() {
   const router = useRouter();
   const authState = useSyncExternalStore(subscribeAuth, getAuthSnapshot, getServerAuthSnapshot);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusedElementRef = useRef<HTMLElement | null>(null);
   const { loggedIn, isAdmin, userName } = authState;
+  const displayUserName = getDisplayUserName(userName);
+  const isUsersNewActive = pathname === "/users/new";
 
   const getNavLinkClassName = (href: string) => {
     return pathname === href ? `${styles.link} ${styles.active}` : styles.link;
@@ -75,31 +93,80 @@ export default function GlobalHeaderNav() {
   }, [router]);
 
   const onLogoutClick = useCallback(() => {
+    setIsSubmitting(false);
     setShowLogoutConfirm(true);
   }, []);
 
   const onCancelLogout = useCallback(() => {
+    if (isSubmitting) return;
     setShowLogoutConfirm(false);
-  }, []);
+  }, [isSubmitting]);
 
   const onConfirmLogout = useCallback(() => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     logout();
-    setShowLogoutConfirm(false);
     router.push("/login");
-  }, [router]);
+  }, [isSubmitting, router]);
+
+  useEffect(() => {
+    if (!showLogoutConfirm) {
+      previousFocusedElementRef.current?.focus();
+      previousFocusedElementRef.current = null;
+      return;
+    }
+
+    previousFocusedElementRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    cancelButtonRef.current?.focus();
+  }, [showLogoutConfirm]);
 
   useEffect(() => {
     if (!showLogoutConfirm) return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         onCancelLogout();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusableElements = getFocusableButtons(cancelButtonRef.current, confirmButtonRef.current);
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !dialog.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (active === last || !dialog.contains(active)) {
+        event.preventDefault();
+        first.focus();
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    dialog.addEventListener("keydown", handleKeyDown);
+    return () => dialog.removeEventListener("keydown", handleKeyDown);
   }, [showLogoutConfirm, onCancelLogout]);
 
   if (pathname === "/login") {
@@ -114,8 +181,8 @@ export default function GlobalHeaderNav() {
         </Link>
         <nav className={styles.nav} aria-label="global">
           {loggedIn && (
-            <span className={styles.userStatus} aria-label={`ログイン中ユーザー: ${userName ?? "ユーザ"}`}>
-              ログイン中: {userName ?? "ユーザ"}
+            <span className={styles.userStatus} aria-label={`ログイン中ユーザー: ${displayUserName}`}>
+              ログイン中: {displayUserName}
             </span>
           )}
           {NAV_ITEMS.map((item) => {
@@ -134,7 +201,7 @@ export default function GlobalHeaderNav() {
           {isAdmin && (
             <Link
               href="/users/new"
-              aria-current={pathname === "/users/new" ? "page" : undefined}
+              aria-current={isUsersNewActive ? "page" : undefined}
               className={getNavLinkClassName("/users/new")}
             >
               社員登録
@@ -154,21 +221,24 @@ export default function GlobalHeaderNav() {
       {showLogoutConfirm && (
         <div className={styles.modalOverlay} role="presentation" onClick={onCancelLogout}>
           <div
+            ref={dialogRef}
             className={styles.modal}
             role="dialog"
             aria-modal="true"
             aria-labelledby="logout-confirm-title"
             aria-describedby="logout-confirm-description"
+            aria-busy={isSubmitting}
+            tabIndex={-1}
             onClick={(event) => event.stopPropagation()}
           >
             <h2 id="logout-confirm-title" className={styles.modalTitle}>ログアウトしますか？</h2>
             <p id="logout-confirm-description" className={styles.modalDescription}>未保存の入力内容は失われる可能性があります。</p>
             <div className={styles.modalActions}>
-              <button type="button" className={styles.cancelButton} onClick={onCancelLogout}>
+              <button type="button" className={styles.cancelButton} onClick={onCancelLogout} disabled={isSubmitting} ref={cancelButtonRef}>
                 いいえ
               </button>
-              <button type="button" className={styles.confirmButton} onClick={onConfirmLogout}>
-                はい
+              <button type="button" className={styles.confirmButton} onClick={onConfirmLogout} disabled={isSubmitting} ref={confirmButtonRef}>
+                {isSubmitting ? "処理中..." : "はい"}
               </button>
             </div>
           </div>

--- a/frontend/src/components/global-header-nav.tsx
+++ b/frontend/src/components/global-header-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { logout } from "@/lib/api";
@@ -18,6 +18,40 @@ type AuthState = {
   userName: string | null;
 };
 
+const SERVER_AUTH_SNAPSHOT: AuthState = {
+  loggedIn: false,
+  isAdmin: false,
+  userName: null,
+};
+
+let cachedAuthSnapshot: AuthState = SERVER_AUTH_SNAPSHOT;
+
+const readAuthState = (): AuthState => {
+  const loggedIn = hasAccessToken();
+  return {
+    loggedIn,
+    isAdmin: loggedIn && isAdminUser(),
+    userName: getLoggedInUserName(),
+  };
+};
+
+const getAuthSnapshot = (): AuthState => {
+  const next = readAuthState();
+  if (
+    cachedAuthSnapshot.loggedIn === next.loggedIn
+    && cachedAuthSnapshot.isAdmin === next.isAdmin
+    && cachedAuthSnapshot.userName === next.userName
+  ) {
+    return cachedAuthSnapshot;
+  }
+  cachedAuthSnapshot = next;
+  return cachedAuthSnapshot;
+};
+
+const getServerAuthSnapshot = (): AuthState => SERVER_AUTH_SNAPSHOT;
+
+const subscribeAuth = () => () => {};
+
 const NAV_ITEMS: NavItem[] = [
   { href: "/", label: "トップ" },
   { href: "/users", label: "社員一覧" },
@@ -28,28 +62,13 @@ const NAV_ITEMS: NavItem[] = [
 export default function GlobalHeaderNav() {
   const pathname = usePathname();
   const router = useRouter();
-  const [authState, setAuthState] = useState<AuthState>({
-    loggedIn: false,
-    isAdmin: false,
-    userName: null,
-  });
+  const authState = useSyncExternalStore(subscribeAuth, getAuthSnapshot, getServerAuthSnapshot);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { loggedIn, isAdmin, userName } = authState;
 
-  const syncAuthStateFromStorage = () => {
-    const loggedIn = hasAccessToken();
-    setAuthState({
-      loggedIn,
-      isAdmin: loggedIn && isAdminUser(),
-      userName: getLoggedInUserName(),
-    });
+  const getNavLinkClassName = (href: string) => {
+    return pathname === href ? `${styles.link} ${styles.active}` : styles.link;
   };
-
-  useEffect(() => {
-    syncAuthStateFromStorage();
-    setIsSubmitting(false);
-    setShowLogoutConfirm(false);
-  }, [pathname]);
 
   const onLogin = useCallback(() => {
     router.push("/login");
@@ -60,22 +79,14 @@ export default function GlobalHeaderNav() {
   }, []);
 
   const onCancelLogout = useCallback(() => {
-    if (isSubmitting) return;
     setShowLogoutConfirm(false);
-  }, [isSubmitting]);
+  }, []);
 
   const onConfirmLogout = useCallback(() => {
-    if (isSubmitting) return;
-    setIsSubmitting(true);
-    try {
-      logout();
-      setAuthState({ loggedIn: false, isAdmin: false, userName: null });
-      setShowLogoutConfirm(false);
-      router.push("/login");
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [isSubmitting, router]);
+    logout();
+    setShowLogoutConfirm(false);
+    router.push("/login");
+  }, [router]);
 
   useEffect(() => {
     if (!showLogoutConfirm) return;
@@ -85,15 +96,11 @@ export default function GlobalHeaderNav() {
         event.preventDefault();
         onCancelLogout();
       }
-      if (event.key === "Enter") {
-        event.preventDefault();
-        onConfirmLogout();
-      }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [showLogoutConfirm, onCancelLogout, onConfirmLogout]);
+  }, [showLogoutConfirm, onCancelLogout]);
 
   if (pathname === "/login") {
     return null;
@@ -106,9 +113,9 @@ export default function GlobalHeaderNav() {
           OfficeNavi
         </Link>
         <nav className={styles.nav} aria-label="global">
-          {authState.loggedIn && (
-            <span className={styles.userStatus} aria-label={`ログイン中ユーザー: ${authState.userName ?? "ユーザ"}`}>
-              ログイン中: {authState.userName ?? "ユーザ"}
+          {loggedIn && (
+            <span className={styles.userStatus} aria-label={`ログイン中ユーザー: ${userName ?? "ユーザ"}`}>
+              ログイン中: {userName ?? "ユーザ"}
             </span>
           )}
           {NAV_ITEMS.map((item) => {
@@ -118,28 +125,28 @@ export default function GlobalHeaderNav() {
                 key={item.href}
                 href={item.href}
                 aria-current={active ? "page" : undefined}
-                className={active ? `${styles.link} ${styles.active}` : styles.link}
+                className={getNavLinkClassName(item.href)}
               >
                 {item.label}
               </Link>
             );
           })}
-          {authState.isAdmin && (
+          {isAdmin && (
             <Link
               href="/users/new"
               aria-current={pathname === "/users/new" ? "page" : undefined}
-              className={pathname === "/users/new" ? `${styles.link} ${styles.active}` : styles.link}
+              className={getNavLinkClassName("/users/new")}
             >
               社員登録
             </Link>
           )}
           <button
             type="button"
-            onClick={authState.loggedIn ? onLogoutClick : onLogin}
+            onClick={loggedIn ? onLogoutClick : onLogin}
             className={styles.logoutButton}
-            aria-label={authState.loggedIn ? "ログアウト" : "ログイン"}
+            aria-label={loggedIn ? "ログアウト" : "ログイン"}
           >
-            {authState.loggedIn ? "ログアウト" : "ログイン"}
+            {loggedIn ? "ログアウト" : "ログイン"}
           </button>
         </nav>
       </div>
@@ -151,16 +158,17 @@ export default function GlobalHeaderNav() {
             role="dialog"
             aria-modal="true"
             aria-labelledby="logout-confirm-title"
+            aria-describedby="logout-confirm-description"
             onClick={(event) => event.stopPropagation()}
           >
             <h2 id="logout-confirm-title" className={styles.modalTitle}>ログアウトしますか？</h2>
-            <p className={styles.modalDescription}>未保存の入力内容は失われる可能性があります。</p>
+            <p id="logout-confirm-description" className={styles.modalDescription}>未保存の入力内容は失われる可能性があります。</p>
             <div className={styles.modalActions}>
-              <button type="button" className={styles.cancelButton} onClick={onCancelLogout} disabled={isSubmitting}>
+              <button type="button" className={styles.cancelButton} onClick={onCancelLogout}>
                 いいえ
               </button>
-              <button type="button" className={styles.confirmButton} onClick={onConfirmLogout} disabled={isSubmitting}>
-                {isSubmitting ? "処理中..." : "はい"}
+              <button type="button" className={styles.confirmButton} onClick={onConfirmLogout}>
+                はい
               </button>
             </div>
           </div>


### PR DESCRIPTION
# 概要
- ログアウト確認ダイアログ実装に伴う状態管理を見直し、Hydration mismatch と「処理中...」状態の残留を解消した。
- あわせて `GlobalHeaderNav` のリファクタリングを実施し、認証状態・イベントハンドラ管理の可読性と保守性を向上した。

# 関連Issue
- Issue: #65 

# 変更内容
- Backend:
  - なし
- Frontend:
  - `global-header-nav.tsx`
    - ログアウト確認モーダル（はい/いいえ）を実装
    - Esc/Enter キー対応を実装
    - 認証表示状態を `AuthState` に集約して管理
    - ルート遷移時に認証状態・モーダル状態・送信中状態を同期/リセット
    - `useCallback` 導入でハンドラ依存を明確化し、Hook依存警告を解消
    - ログアウト直後の状態更新を明示化し、処理中状態の取り残しを防止
  - `global-header-nav.module.css`
    - 確認モーダル表示に必要なスタイルを追加
    - ボタン活性/非活性時の見た目を調整

# 動作確認内容
1. 手順:
   - ログイン状態でヘッダーの「ログアウト」を押下
   - 確認ダイアログで「いいえ」を選択
   - 再度ログアウトを押下し「はい」を選択
   - ログイン後すぐに再度ログアウト操作を実施
2. 期待結果:
   - ログアウト時に確認ダイアログが表示される
   - 「いいえ」でログアウトされない
   - 「はい」でログアウトし、ログイン画面へ遷移する
   - 「処理中...」が次操作に持ち越されず、操作が固まらない
   - Hydration mismatch / Hook依存警告が発生しない（`npm run lint` 成功）

# リスク・影響範囲
- 影響範囲:
  - 全画面共通ヘッダー（`GlobalHeaderNav`）の表示・操作
  - ログイン/ログアウト導線
- 懸念点:
  - `localStorage` ベース認証のため、将来的な SSR 完全整合には Cookie(HttpOnly) 方式への移行検討余地あり