### PR TITLE
feat: フロアマップの空席クリックで在席登録できる確認ダイアログを追加

### DIFF
--- a/frontend/src/app/current-seat-lookup/current-seat-lookup-page.module.css
+++ b/frontend/src/app/current-seat-lookup/current-seat-lookup-page.module.css
@@ -193,6 +193,15 @@
   gap: 8px;
 }
 
+.noticeBox {
+  border-radius: 10px;
+  padding: 10px 12px;
+  border: 1px solid #a7f3d0;
+  background: #ecfdf5;
+  color: #065f46;
+  margin: 0;
+}
+
 .floorMapSection {
   display: grid;
   gap: 16px;
@@ -202,6 +211,45 @@
   color: #102a43;
   font-size: 18px;
   margin: 0;
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: rgba(2, 6, 23, 0.45);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.modal {
+  width: min(420px, 100%);
+  border-radius: 14px;
+  border: 1px solid #d9e2ec;
+  background: #fff;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.modal h2 {
+  margin: 0;
+  color: #102a43;
+  font-size: 18px;
+}
+
+.modal p {
+  margin: 0;
+  color: #486581;
+  font-size: 14px;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 @media (max-width: 680px) {

--- a/frontend/src/app/current-seat-lookup/page.tsx
+++ b/frontend/src/app/current-seat-lookup/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { FormEvent, useState, useEffect, useMemo } from "react";
+import { FormEvent, useState, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { ApiClientError, getAllCurrentSeats, getCurrentSeatByUserId, getSeats } from "@/lib/api";
+import { ApiClientError, getAllCurrentSeats, getCurrentSeatByUserId, getSeats, registerCurrentSeat } from "@/lib/api";
 import { hasAccessToken } from "@/lib/api/client";
 import type { CurrentSeat, Seat } from "@/types/api";
 import styles from "./current-seat-lookup-page.module.css";
@@ -16,6 +16,15 @@ const normalizeLocation = (location?: string | null) => {
   return location && location.trim() ? location : "場所未設定";
 };
 
+const getSeatConflictMessage = (error: ApiClientError) => {
+  const detail = error.details.find((item) => item.field === "seatId");
+  if (detail?.reason) {
+    return `${detail.reason}。別の座席を選択して再試行してください。`;
+  }
+
+  return "指定された座席は既に利用中です。別の座席を選択して再試行してください。";
+};
+
 export default function CurrentSeatLookupPage() {
   const router = useRouter();
   const [userIdInput, setUserIdInput] = useState("");
@@ -24,12 +33,20 @@ export default function CurrentSeatLookupPage() {
   const [loading, setLoading] = useState(false);
   const [emptyMessage, setEmptyMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const [noticeMessage, setNoticeMessage] = useState("");
   const [allSeats, setAllSeats] = useState<Seat[]>([]);
   const [occupiedSeats, setOccupiedSeats] = useState<CurrentSeat[]>([]);
+  const [confirmingSeat, setConfirmingSeat] = useState<Seat | null>(null);
+  const [registeringSeatId, setRegisteringSeatId] = useState<number | null>(null);
+
+  const seatRegisterDialogRef = useRef<HTMLDivElement>(null);
+  const seatRegisterCancelButtonRef = useRef<HTMLButtonElement>(null);
+  const seatRegisterConfirmButtonRef = useRef<HTMLButtonElement>(null);
 
   const clearMessages = () => {
     setEmptyMessage("");
     setErrorMessage("");
+    setNoticeMessage("");
   };
 
   const lookupAll = async () => {
@@ -91,6 +108,12 @@ export default function CurrentSeatLookupPage() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (confirmingSeat) {
+      seatRegisterCancelButtonRef.current?.focus();
+    }
+  }, [confirmingSeat]);
 
   useEffect(() => {
     if (!hasAccessToken()) {
@@ -167,6 +190,76 @@ export default function CurrentSeatLookupPage() {
     await lookupByUserId(submittedUserId);
   };
 
+  const onSelectAvailableSeat = (seat: Seat) => {
+    if (registeringSeatId !== null) return;
+    clearMessages();
+    setConfirmingSeat(seat);
+  };
+
+  const onCancelSeatRegister = () => {
+    if (registeringSeatId !== null) return;
+    setConfirmingSeat(null);
+  };
+
+  const onConfirmSeatRegister = async () => {
+    if (!confirmingSeat || registeringSeatId !== null) return;
+
+    const targetSeat = confirmingSeat;
+    setRegisteringSeatId(targetSeat.id);
+    setErrorMessage("");
+    setNoticeMessage("");
+
+    // ① 在席登録
+    try {
+      await registerCurrentSeat({ seatId: targetSeat.id });
+    } catch (err) {
+      if (err instanceof ApiClientError && err.status === 409) {
+        setErrorMessage(getSeatConflictMessage(err));
+      } else if (err instanceof ApiClientError && err.status === 401) {
+        router.replace("/login");
+        return;
+      } else if (err instanceof ApiClientError) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage("在席登録に失敗しました。");
+      }
+      setRegisteringSeatId(null);
+      setConfirmingSeat(null);
+      return;
+    }
+
+    // ② 登録成功 → ダイアログを閉じて成功通知
+    setNoticeMessage(`${targetSeat.name} に着席登録しました。`);
+    setRegisteringSeatId(null);
+    setConfirmingSeat(null);
+
+    // ③ フロアマップ / 照会結果を最新化（失敗しても登録成功は確定済み）
+    try {
+      const latestSeats = await getAllCurrentSeats();
+      setOccupiedSeats(latestSeats);
+      if (submittedUserId === null) {
+        setResults(latestSeats);
+      }
+    } catch {
+      setErrorMessage("表示の更新に失敗しました。ページを再読み込みしてください。");
+    }
+  };
+
+  const onSeatRegisterDialogKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      onCancelSeatRegister();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const cancel = seatRegisterCancelButtonRef.current;
+    const confirm = seatRegisterConfirmButtonRef.current;
+    if (!cancel || !confirm) return;
+    if (e.shiftKey ? document.activeElement === cancel : document.activeElement === confirm) {
+      e.preventDefault();
+      (e.shiftKey ? confirm : cancel).focus();
+    }
+  };
+
   const locationGroups = useMemo(
     () => allSeats.reduce<Record<string, Seat[]>>((acc, seat) => {
       const key = normalizeLocation(seat.location);
@@ -211,6 +304,8 @@ export default function CurrentSeatLookupPage() {
                 location={location}
                 seats={locationSeats}
                 occupiedSeats={occupiedSeatsByLocation[location] ?? []}
+                onSelectAvailableSeat={onSelectAvailableSeat}
+                selectingSeatId={registeringSeatId}
               />
             ))}
           </section>
@@ -246,6 +341,8 @@ export default function CurrentSeatLookupPage() {
             )}
           </section>
         )}
+
+        {noticeMessage && <p className={styles.noticeBox}>{noticeMessage}</p>}
 
         {emptyMessage && <p className={styles.empty}>{emptyMessage}</p>}
 
@@ -284,6 +381,34 @@ export default function CurrentSeatLookupPage() {
         )}
 
       </main>
+
+      {confirmingSeat && (
+        <div className={styles.modalOverlay} role="presentation" onClick={onCancelSeatRegister}>
+          <div
+            ref={seatRegisterDialogRef}
+          className={styles.modal}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="seat-register-title"
+            aria-describedby="seat-register-description"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={onSeatRegisterDialogKeyDown}
+          >
+            <h2 id="seat-register-title">ここに座りますか？</h2>
+            <p id="seat-register-description">
+              対象座席: {confirmingSeat.name}（{normalizeLocation(confirmingSeat.location)}）
+            </p>
+            <div className={styles.modalActions}>
+              <button ref={seatRegisterCancelButtonRef} type="button" className={styles.retry} onClick={onCancelSeatRegister} disabled={registeringSeatId !== null}>
+                いいえ
+              </button>
+              <button ref={seatRegisterConfirmButtonRef} type="button" className={styles.primary} onClick={onConfirmSeatRegister} disabled={registeringSeatId !== null}>
+                {registeringSeatId !== null ? "登録中..." : "はい"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/floor-map.module.css
+++ b/frontend/src/components/floor-map.module.css
@@ -95,6 +95,10 @@
   filter: drop-shadow(0 2px 4px rgba(16, 185, 129, 0.3));
 }
 
+.seatSelectable {
+  cursor: pointer;
+}
+
 .seatOccupied {
   fill: #fef2f2;
   stroke: #ef4444;

--- a/frontend/src/components/floor-map.tsx
+++ b/frontend/src/components/floor-map.tsx
@@ -12,13 +12,15 @@ interface FloorMapProps {
   location: string;
   seats: Seat[];
   occupiedSeats: CurrentSeat[];
+  onSelectAvailableSeat?: (seat: Seat) => void;
+  selectingSeatId?: number | null;
 }
 
 const formatOccupantName = (name: string, maxLength = 6): string => {
   return name.length > maxLength ? `${name.slice(0, maxLength)}…` : name;
 };
 
-export default function FloorMap({ location, seats, occupiedSeats }: FloorMapProps) {
+export default function FloorMap({ location, seats, occupiedSeats, onSelectAvailableSeat, selectingSeatId = null }: FloorMapProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -35,6 +37,11 @@ export default function FloorMap({ location, seats, occupiedSeats }: FloorMapPro
   const occupiedMap = useMemo(
     () => new Map<number, CurrentSeat>(occupiedSeats.map((cs) => [cs.seat.id, cs])),
     [occupiedSeats]
+  );
+
+  const seatById = useMemo(
+    () => new Map<number, Seat>(seats.map((seat) => [seat.id, seat])),
+    [seats]
   );
 
   // マウスホイールでズーム
@@ -156,13 +163,25 @@ export default function FloorMap({ location, seats, occupiedSeats }: FloorMapPro
           {/* 座席 */}
           {seatCoordinates.map((coord) => {
             const occupied = occupiedMap.get(coord.seatId);
+            const seat = seatById.get(coord.seatId);
+            const isSelectable = !!onSelectAvailableSeat && !occupied && selectingSeatId === null;
             const seatRadius = coord.section === "A" ? SEAT_SIZE.A_SEAT_RADIUS : SEAT_SIZE.GRID_CIRCLE_SEAT_RADIUS;
             const centerX = coord.shape === "rect" ? coord.x + SEAT_SIZE.WIDTH / 2 : coord.x + seatRadius;
             const sectionLabelY = coord.shape === "rect" ? coord.y + 22 : coord.y + seatRadius - 6;
             const secondaryLabelY = coord.shape === "rect" ? coord.y + 36 : coord.y + seatRadius + 8;
             const secondaryText = occupied ? formatOccupantName(occupied.userName) : String(coord.number);
+
+            const handleSeatClick = () => {
+              if (!isSelectable || !seat || !onSelectAvailableSeat) return;
+              onSelectAvailableSeat(seat);
+            };
+
             return (
-              <g key={coord.seatId}>
+              <g
+                key={coord.seatId}
+                onClick={handleSeatClick}
+                className={isSelectable ? styles.seatSelectable : undefined}
+              >
                 {occupied && <title>{occupied.userName}</title>}
                 {coord.shape === "rect" ? (
                   <rect


### PR DESCRIPTION
# 概要
- フロアマップ上の空席をクリックすると確認ダイアログが表示され、「はい」を押すと在席登録できる機能を追加した。

# 関連Issue
- Issue: #60 

# 変更内容
- Backend:
  - なし
- Frontend:
  - `FloorMap` コンポーネントに `onSelectAvailableSeat` / `selectingSeatId` プロパティを追加し、空席クリック時に親コンポーネントへ通知する仕組みを実装
  - 現在位置照会ページ（`current-seat-lookup/page.tsx`）に確認ダイアログを追加
    - 在席登録（`registerCurrentSeat`）と表示更新（`getAllCurrentSeats`）を独立した `try/catch` に分離し、表示更新失敗時でも登録成功メッセージを正しく表示する
    - ダイアログのフォーカス管理（初期フォーカス / Tab trap / Esc 閉じ）を実装
  - 確認ダイアログ・成功通知ボックス用スタイルを追加

# 動作確認内容
1. 手順: フロアマップの空席（白色の座席）をクリック → 確認ダイアログが表示されることを確認
2. 手順: 「はい」ボタンを押す → 在席登録され、座席が占有状態に切り替わることを確認
3. 手順: 「いいえ」ボタンまたは Esc キーを押す → ダイアログが閉じ、登録が行われないことを確認
4. 手順: 既に占有中の座席をクリック → ダイアログが表示されないことを確認
5. 期待結果: 上記すべてが意図通りに動作する

# リスク・影響範囲
- 影響範囲: 現在位置照会ページ・FloorMap コンポーネント（他ページでの FloorMap 利用箇所は props 追加のみのため既存動作に影響なし）
- 懸念点: 在席登録後の `getAllCurrentSeats` が失敗した場合、フロアマップと照会結果の表示が古いままになる（ページ再読み込みで解消）