### PR TITLE
test: バックエンドテストを再構築

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,29 @@ npm run build
 
 ---
 
+## テスト方針
+
+バックエンドは `src/test/java` 配下で、主に Controller 層と Service 層の単体テストを実装しています。
+
+### Controller テスト
+
+- `MockMvc` を用いて HTTP ステータスとレスポンス JSON を検証
+- 正常系に加えて、入力バリデーション、認証失敗、`404 Not Found`、`409 Conflict` を確認
+- `ApiExceptionHandler` を含めたエラーレスポンス形式を固定
+
+### Service テスト
+
+- Repository / Encoder / JWT 生成器をモック化して業務ロジックを検証
+- 正常系に加えて、存在チェック、競合、認証失敗などの分岐を確認
+- 在席登録・退席・現在位置照会など、主要ユースケースの戻り値変換も検証
+
+### 実行方法
+
+- 全件実行: `./mvnw test`
+- 個別実行例: `./mvnw -Dtest=AuthControllerTest test`
+
+---
+
 ## リポジトリ構成
 
 ```text

--- a/src/test/java/com/example/officenavi/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/AuthControllerTest.java
@@ -1,0 +1,178 @@
+package com.example.officenavi.controller;
+
+import com.example.officenavi.domain.auth.LoginResponse;
+import com.example.officenavi.exception.AuthenticationFailedException;
+import com.example.officenavi.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthControllerTest {
+
+    private MockMvc mockMvc;
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = mock(AuthService.class);
+
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new AuthController(authService))
+                .setControllerAdvice(new ApiExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    void login_shouldReturn200AndToken() throws Exception {
+        when(authService.login(any())).thenReturn(new LoginResponse(
+                "token-123",
+                "Bearer",
+                3600,
+                1,
+                "山田太郎"));
+
+        String body = """
+                {
+                  "email": "taro@example.com",
+                  "password": "Passw0rd"
+                }
+                """;
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("token-123"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.expiresIn").value(3600))
+                .andExpect(jsonPath("$.roleCode").value(1))
+                .andExpect(jsonPath("$.userName").value("山田太郎"));
+    }
+
+    @Test
+    void login_withMissingEmail_shouldReturn400ValidationError() throws Exception {
+        String body = """
+                {
+                  "password": "Passw0rd"
+                }
+                """;
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("email")));
+
+        verifyNoInteractions(authService);
+    }
+
+    @Test
+    void login_withMissingPassword_shouldReturn400ValidationError() throws Exception {
+        String body = """
+                {
+                  "email": "taro@example.com"
+                }
+                """;
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("password")));
+
+        verifyNoInteractions(authService);
+    }
+
+    @Test
+    void login_withEmptyEmail_shouldReturn400ValidationError() throws Exception {
+        String body = """
+                {
+                  "email": "",
+                  "password": "Passw0rd"
+                }
+                """;
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("email")));
+
+        verifyNoInteractions(authService);
+    }
+
+    @Test
+    void login_withInvalidEmailFormat_shouldReturn400ValidationError() throws Exception {
+        String body = """
+                {
+                  "email": "invalid-email",
+                  "password": "Passw0rd"
+                }
+                """;
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("email")));
+
+        verifyNoInteractions(authService);
+    }
+
+    @Test
+    void login_withEmptyPassword_shouldReturn400ValidationError() throws Exception {
+        String body = """
+                {
+                  "email": "taro@example.com",
+                  "password": ""
+                }
+                """;
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("validation error"))
+                .andExpect(jsonPath("$.errors[*].field", hasItems("password")));
+
+        verifyNoInteractions(authService);
+    }
+
+    @Test
+    void login_whenAuthenticationFailed_shouldReturn401() throws Exception {
+        when(authService.login(any())).thenThrow(new AuthenticationFailedException("emailまたはpasswordが不正です"));
+
+        String body = """
+                {
+                  "email": "taro@example.com",
+                  "password": "wrong-pass"
+                }
+                """;
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"))
+                .andExpect(jsonPath("$.message").value("emailまたはpasswordが不正です"));
+    }
+}

--- a/src/test/java/com/example/officenavi/controller/SeatControllerTest.java
+++ b/src/test/java/com/example/officenavi/controller/SeatControllerTest.java
@@ -40,4 +40,14 @@ class SeatControllerTest {
                 .andExpect(jsonPath("$[1].location").value("3F East"));
 
     }
+
+    @Test
+    void getSeats_whenNoSeat_shouldReturn200AndEmptyArray() throws Exception {
+        when(seatService.getSeats()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/seats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
 }

--- a/src/test/java/com/example/officenavi/service/AuthServiceTest.java
+++ b/src/test/java/com/example/officenavi/service/AuthServiceTest.java
@@ -1,0 +1,87 @@
+package com.example.officenavi.service;
+
+import com.example.officenavi.domain.auth.LoginRequest;
+import com.example.officenavi.domain.auth.LoginResponse;
+import com.example.officenavi.domain.user.UserEntity;
+import com.example.officenavi.exception.AuthenticationFailedException;
+import com.example.officenavi.repository.UserRepository;
+import com.example.officenavi.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthServiceTest {
+
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private JwtTokenProvider jwtTokenProvider;
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        authService = new AuthService(userRepository, passwordEncoder, jwtTokenProvider);
+    }
+
+    @Test
+    void login_shouldReturnTokenResponse() {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("taro@example.com");
+        request.setPassword("Passw0rd");
+
+        UserEntity user = new UserEntity("山田太郎", "taro@example.com", "hashed");
+        user.setId(1);
+        user.setRoleCode(1);
+
+        when(userRepository.findByEmailForAuth("taro@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(eq("Passw0rd"), eq("hashed"))).thenReturn(true);
+        when(jwtTokenProvider.generateToken(1, "taro@example.com", 1)).thenReturn("token-123");
+        when(jwtTokenProvider.getExpirationSeconds()).thenReturn(3600L);
+
+        LoginResponse response = authService.login(request);
+
+        assertEquals("token-123", response.getAccessToken());
+        assertEquals("Bearer", response.getTokenType());
+        assertEquals(3600L, response.getExpiresIn());
+        assertEquals(1, response.getRoleCode());
+        assertEquals("山田太郎", response.getUserName());
+    }
+
+    @Test
+    void login_whenUserNotFound_shouldThrowAuthenticationFailedException() {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("notfound@example.com");
+        request.setPassword("Passw0rd");
+
+        when(userRepository.findByEmailForAuth("notfound@example.com")).thenReturn(Optional.empty());
+
+        assertThrows(AuthenticationFailedException.class, () -> authService.login(request));
+    }
+
+    @Test
+    void login_whenPasswordMismatch_shouldThrowAuthenticationFailedException() {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("taro@example.com");
+        request.setPassword("wrong-pass");
+
+        UserEntity user = new UserEntity("山田太郎", "taro@example.com", "hashed");
+        user.setId(1);
+        user.setRoleCode(1);
+
+        when(userRepository.findByEmailForAuth("taro@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(any(), eq("hashed"))).thenReturn(false);
+
+        assertThrows(AuthenticationFailedException.class, () -> authService.login(request));
+    }
+}

--- a/src/test/java/com/example/officenavi/service/UserSeatServiceTest.java
+++ b/src/test/java/com/example/officenavi/service/UserSeatServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -153,6 +154,32 @@ public class UserSeatServiceTest {
         when(userSeatRepository.findCurrentSeatByUserId(USER_ID)).thenReturn(Optional.empty());
 
         assertThrows(ResourceNotFoundException.class, () -> userSeatService.getCurrentSeat(USER_ID));
+    }
+
+    @Test
+    void getAllCurrentSeats_shouldReturnMappedResponses() {
+        LocalDateTime since = LocalDateTime.now();
+        when(userSeatRepository.findAllCurrentSeats()).thenReturn(List.of(
+                new UserCurrentSeatEntity(1, "山田太郎", 10, "A-01", "3F East", since),
+                new UserCurrentSeatEntity(2, "佐藤花子", 20, "B-10", "4F West", since)));
+
+        List<UserCurrentSeatResponse> responses = userSeatService.getAllCurrentSeats();
+
+        assertEquals(2, responses.size());
+        assertEquals(1, responses.get(0).getUserId());
+        assertEquals("山田太郎", responses.get(0).getUserName());
+        assertEquals(10, responses.get(0).getSeat().getId());
+        assertEquals("A-01", responses.get(0).getSeat().getName());
+        assertEquals("3F East", responses.get(0).getSeat().getLocation());
+    }
+
+    @Test
+    void getAllCurrentSeats_shouldReturnEmptyListWhenNoCurrentSeats() {
+        when(userSeatRepository.findAllCurrentSeats()).thenReturn(List.of());
+
+        List<UserCurrentSeatResponse> responses = userSeatService.getAllCurrentSeats();
+
+        assertEquals(0, responses.size());
     }
 
 }


### PR DESCRIPTION
# 概要
- `AuthControllerTest` で認証失敗時のバリデーションエラーレスポンス形式（`message/errors`）と実装が乖離しており、テストが失敗していた
- テスト全体を見直し、不足していたケースを補強した
- README にテスト方針セクションを追記した

# 関連Issue
- Issue: #（なし）

# 変更内容
- Backend:
  - `AuthControllerTest.java` 新規作成（7テスト）
    - ログイン正常系、バリデーション（メール/パスワード必須・空・形式不正）、認証失敗401
  - `AuthServiceTest.java` 新規作成（3テスト）
    - 正常系（トークン・roleCode・userName 検証）、ユーザー不在、パスワード不一致
  - `SeatControllerTest.java` 補強：座席一覧が空の場合の境界値テストを追加
  - `UserSeatServiceTest.java` 補強：`getAllCurrentSeats` のマッピング変換ロジックと空配列ケースを追加
  - `README.md` に `## テスト方針` セクションを追記（実行方法・Controller/Service の観点を記載）
- Frontend:
  - なし

# 動作確認内容
1. 手順: `./mvnw test` を実行
2. 期待結果: `Tests run: 65, Failures: 0, Errors: 0, Skipped: 0` → BUILD SUCCESS ✅

# リスク・影響範囲
- 影響範囲: テストコードと README のみ。本体の実装変更なし
- 懸念点: なし